### PR TITLE
chore: localized global dependencies in dev mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Dependencies
 node_modules/
 npm-debug.log*
+.dependencies/
 
 # Log4brains
 .log4brains/

--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,6 @@
 
         rustToolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
 
-        dependenciesDir = "./.dependencies";
       in
       {
         devShells.default = pkgs.mkShell {
@@ -42,17 +41,19 @@
 
           RUST_SRC_PATH = "${rustToolchain}/lib/rustlib/src/rust/library";
 
-          CARGO_HOME = "${dependenciesDir}/cargo";
-          CARGO_INSTALL_ROOT = "${dependenciesDir}/cargo";
-          npm_config_prefix = "${dependenciesDir}/npm";
-          BUN_INSTALL = "${dependenciesDir}/bun";
-
           shellHook = ''
-            mkdir -p ${dependenciesDir}/cargo/bin
-            mkdir -p ${dependenciesDir}/npm/bin
-            mkdir -p ${dependenciesDir}/bun/bin
+            dependenciesDir="$PWD/.dependencies"
 
-            export PATH="${dependenciesDir}/cargo/bin:${dependenciesDir}/npm/bin:${dependenciesDir}/bun/bin:$PATH"
+            export CARGO_HOME="$dependenciesDir/cargo"
+            export CARGO_INSTALL_ROOT="$dependenciesDir/cargo"
+            export npm_config_prefix="$dependenciesDir/npm"
+            export BUN_INSTALL="$dependenciesDir/bun"
+
+            mkdir -p "$dependenciesDir"/cargo/bin
+            mkdir -p "$dependenciesDir"/npm/bin
+            mkdir -p "$dependenciesDir"/bun/bin
+
+            export PATH="$dependenciesDir/cargo/bin:$dependenciesDir/npm/bin:$dependenciesDir/bun/bin:$PATH"
           '';
         };
       }

--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,8 @@
         };
 
         rustToolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+
+        dependenciesDir = "./.dependencies";
       in
       {
         devShells.default = pkgs.mkShell {
@@ -31,6 +33,7 @@
             git
             lefthook
             nodejs_22
+            bun
             glow
             jq
             sqlx-cli
@@ -38,6 +41,19 @@
           ];
 
           RUST_SRC_PATH = "${rustToolchain}/lib/rustlib/src/rust/library";
+
+          CARGO_HOME = "${dependenciesDir}/cargo";
+          CARGO_INSTALL_ROOT = "${dependenciesDir}/cargo";
+          npm_config_prefix = "${dependenciesDir}/npm";
+          BUN_INSTALL = "${dependenciesDir}/bun";
+
+          shellHook = ''
+            mkdir -p ${dependenciesDir}/cargo/bin
+            mkdir -p ${dependenciesDir}/npm/bin
+            mkdir -p ${dependenciesDir}/bun/bin
+
+            export PATH="${dependenciesDir}/cargo/bin:${dependenciesDir}/npm/bin:${dependenciesDir}/bun/bin:$PATH"
+          '';
         };
       }
     );

--- a/flake.nix
+++ b/flake.nix
@@ -42,18 +42,16 @@
           RUST_SRC_PATH = "${rustToolchain}/lib/rustlib/src/rust/library";
 
           shellHook = ''
-            dependenciesDir="$PWD/.dependencies"
+            repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+            dependenciesDir="$repo_root/.dependencies"
 
             export CARGO_HOME="$dependenciesDir/cargo"
             export CARGO_INSTALL_ROOT="$dependenciesDir/cargo"
             export npm_config_prefix="$dependenciesDir/npm"
             export BUN_INSTALL="$dependenciesDir/bun"
 
-            mkdir -p "$dependenciesDir"/cargo/bin
-            mkdir -p "$dependenciesDir"/npm/bin
-            mkdir -p "$dependenciesDir"/bun/bin
-
-            export PATH="$dependenciesDir/cargo/bin:$dependenciesDir/npm/bin:$dependenciesDir/bun/bin:$PATH"
+            mkdir -p "$CARGO_HOME/bin" "$npm_config_prefix/bin" "$BUN_INSTALL/bin"
+            export PATH="$CARGO_HOME/bin:$npm_config_prefix/bin:$BUN_INSTALL/bin:$PATH"
           '';
         };
       }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Development environment now includes Bun alongside existing tooling.
  * Tool installations (Cargo, npm, Bun) are redirected into a local project dependencies directory and automatically wired into the shell at startup.
  * Newly installed tool binaries are immediately available in the shell session.
  * Local dependency artifacts are ignored from version control to keep repositories clean.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->