### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/jwilger/union_square/compare/v0.2.0...v0.2.1) - 2026-05-04
+
+### Added
+
+- *(application)* add step trampoline workflow model ([#225](https://github.com/jwilger/union_square/pull/225))
+- *(codex)* migrate autonomous harness ([#222](https://github.com/jwilger/union_square/pull/222))
+- *(audit)* refactor audit path on effects and wire production EventCore persistence ([#201](https://github.com/jwilger/union_square/pull/201))
+- define EventCore stream design patterns ([#194](https://github.com/jwilger/union_square/pull/194))
+- add opencode-native guardrails, agents, skills, and plugins ([#173](https://github.com/jwilger/union_square/pull/173))
+- add binary release infrastructure for cross-platform distribution ([#156](https://github.com/jwilger/union_square/pull/156))
+
+### Fixed
+
+- *(codex)* stabilize workflow smoke tests ([#227](https://github.com/jwilger/union_square/pull/227))
+- *(version)* replace primitive String with ModelId in VersionComparison ([#154](https://github.com/jwilger/union_square/pull/154))
+
+### Other
+
+- document squash-merge cleanup workflow ([#235](https://github.com/jwilger/union_square/pull/235))
+- establish performance baseline gates ([#232](https://github.com/jwilger/union_square/pull/232))
+- centralize security and architecture checks ([#230](https://github.com/jwilger/union_square/pull/230))
+- *(deps)* consolidate dependency updates ([#229](https://github.com/jwilger/union_square/pull/229))
+- *(domain)* seal domain entities and encode lifecycle transitions as types ([#203](https://github.com/jwilger/union_square/pull/203))
+- *(domain)* replace domain events and commands with semantic-only types ([#202](https://github.com/jwilger/union_square/pull/202))
+- *(proxy)* split hot-path planning from execution ([#200](https://github.com/jwilger/union_square/pull/200))
+- *(proxy)* quarantine ring buffer as documented performance island ([#199](https://github.com/jwilger/union_square/pull/199))
+- remove stale emit! macro references from rules and agent docs ([#198](https://github.com/jwilger/union_square/pull/198))
+- *(adapter)* move LLM request parsing out of domain core ([#196](https://github.com/jwilger/union_square/pull/196))
+- introduce semantic IO boundary DTOs and conversion seams ([#195](https://github.com/jwilger/union_square/pull/195))
+- localized global dependencies in dev mode ([#193](https://github.com/jwilger/union_square/pull/193))
+- define performance-safe functional core architecture ([#192](https://github.com/jwilger/union_square/pull/192))
+- add path-based conditional execution and single required join job ([#179](https://github.com/jwilger/union_square/pull/179))
+- simplify CRITICAL REMINDER in CLAUDE.md ([#175](https://github.com/jwilger/union_square/pull/175))
+- update flake ([#172](https://github.com/jwilger/union_square/pull/172))
+- complete TDD adoption and implement remaining streaming tests ([#158](https://github.com/jwilger/union_square/pull/158))
+
 ## [0.2.0](https://github.com/jwilger/union_square/compare/v0.1.2...v0.2.0) - 2025-07-28
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4510,7 +4510,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "union_square"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "union_square"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["John Wilger <john@johnwilger.com>"]
 description = "A proxy/wire-tap service for making LLM calls and recording everything that happens in a session for later analysis and test-case extraction"


### PR DESCRIPTION



## 🤖 New release

* `union_square`: 0.2.0 -> 0.2.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.1](https://github.com/jwilger/union_square/compare/v0.2.0...v0.2.1) - 2026-05-04

### Added

- *(application)* add step trampoline workflow model ([#225](https://github.com/jwilger/union_square/pull/225))
- *(codex)* migrate autonomous harness ([#222](https://github.com/jwilger/union_square/pull/222))
- *(audit)* refactor audit path on effects and wire production EventCore persistence ([#201](https://github.com/jwilger/union_square/pull/201))
- define EventCore stream design patterns ([#194](https://github.com/jwilger/union_square/pull/194))
- add opencode-native guardrails, agents, skills, and plugins ([#173](https://github.com/jwilger/union_square/pull/173))
- add binary release infrastructure for cross-platform distribution ([#156](https://github.com/jwilger/union_square/pull/156))

### Fixed

- *(codex)* stabilize workflow smoke tests ([#227](https://github.com/jwilger/union_square/pull/227))
- *(version)* replace primitive String with ModelId in VersionComparison ([#154](https://github.com/jwilger/union_square/pull/154))

### Other

- document squash-merge cleanup workflow ([#235](https://github.com/jwilger/union_square/pull/235))
- establish performance baseline gates ([#232](https://github.com/jwilger/union_square/pull/232))
- centralize security and architecture checks ([#230](https://github.com/jwilger/union_square/pull/230))
- *(deps)* consolidate dependency updates ([#229](https://github.com/jwilger/union_square/pull/229))
- *(domain)* seal domain entities and encode lifecycle transitions as types ([#203](https://github.com/jwilger/union_square/pull/203))
- *(domain)* replace domain events and commands with semantic-only types ([#202](https://github.com/jwilger/union_square/pull/202))
- *(proxy)* split hot-path planning from execution ([#200](https://github.com/jwilger/union_square/pull/200))
- *(proxy)* quarantine ring buffer as documented performance island ([#199](https://github.com/jwilger/union_square/pull/199))
- remove stale emit! macro references from rules and agent docs ([#198](https://github.com/jwilger/union_square/pull/198))
- *(adapter)* move LLM request parsing out of domain core ([#196](https://github.com/jwilger/union_square/pull/196))
- introduce semantic IO boundary DTOs and conversion seams ([#195](https://github.com/jwilger/union_square/pull/195))
- localized global dependencies in dev mode ([#193](https://github.com/jwilger/union_square/pull/193))
- define performance-safe functional core architecture ([#192](https://github.com/jwilger/union_square/pull/192))
- add path-based conditional execution and single required join job ([#179](https://github.com/jwilger/union_square/pull/179))
- simplify CRITICAL REMINDER in CLAUDE.md ([#175](https://github.com/jwilger/union_square/pull/175))
- update flake ([#172](https://github.com/jwilger/union_square/pull/172))
- complete TDD adoption and implement remaining streaming tests ([#158](https://github.com/jwilger/union_square/pull/158))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).