### PR TITLE
feat(application): add step trampoline workflow model

### DIFF
--- a/.codex/specs/issue-188.yaml
+++ b/.codex/specs/issue-188.yaml
@@ -48,3 +48,4 @@ test_trace_ids:
   - successful-session-analysis:tests/application_trampoline.rs::session_analysis_workflow_completes_through_interpreted_effects
   - interpreter-failure:tests/application_trampoline.rs::interpreter_failure_stops_the_trampoline
   - substitute-interpreter:tests/application_trampoline.rs::session_analysis_workflow_runs_with_substitute_interpreter
+  - successful-session-analysis:tests/application_trampoline.rs::session_event_count_enforces_positive_boundary

--- a/.codex/specs/issue-188.yaml
+++ b/.codex/specs/issue-188.yaml
@@ -31,6 +31,14 @@ examples:
     then:
       - the workflow completes without changing workflow code
       - the substitute interpreter observes the same semantic effects
+  - id: event-count-boundary
+    name: session analysis event count rejects zero
+    given:
+      - session analysis reports a semantic count of loaded session events
+    when:
+      - the event count is constructed from zero
+    then:
+      - validation rejects the count before it enters workflow effects
 acceptance_criteria:
   - A minimal reusable effect, step, and trampoline abstraction exists under the application layer.
   - A representative non-hot-path session analysis workflow is expressed as pure steps and interpreted by a shell-provided interpreter.
@@ -48,4 +56,4 @@ test_trace_ids:
   - successful-session-analysis:tests/application_trampoline.rs::session_analysis_workflow_completes_through_interpreted_effects
   - interpreter-failure:tests/application_trampoline.rs::interpreter_failure_stops_the_trampoline
   - substitute-interpreter:tests/application_trampoline.rs::session_analysis_workflow_runs_with_substitute_interpreter
-  - successful-session-analysis:tests/application_trampoline.rs::session_event_count_enforces_positive_boundary
+  - event-count-boundary:tests/application_trampoline.rs::session_event_count_enforces_positive_boundary

--- a/.codex/specs/issue-188.yaml
+++ b/.codex/specs/issue-188.yaml
@@ -1,0 +1,50 @@
+issue: 188
+goal: Provide a reusable step-trampoline model for non-hot-path application orchestration without routing performance-sensitive proxy paths through it.
+examples:
+  - id: successful-session-analysis
+    name: session analysis workflow completes through interpreted effects
+    given:
+      - a session analysis workflow has semantic session and analysis identifiers
+      - the workflow interpreter can load session facts, record the analysis request, and emit telemetry
+    when:
+      - the trampoline runs the workflow
+    then:
+      - each requested effect is interpreted in order
+      - the workflow completes with an analysis-started result
+  - id: interpreter-failure
+    name: interpreter failures stop the trampoline
+    given:
+      - a session analysis workflow has already requested an effect
+      - the interpreter cannot complete that effect
+    when:
+      - the trampoline receives the interpreter failure
+    then:
+      - the trampoline returns an interpreter error
+      - no later workflow effects are interpreted
+  - id: substitute-interpreter
+    name: workflow can run with a substitute interpreter
+    given:
+      - the same session analysis workflow
+      - a different interpreter implementation that returns compatible observations
+    when:
+      - the trampoline runs the workflow with the substitute interpreter
+    then:
+      - the workflow completes without changing workflow code
+      - the substitute interpreter observes the same semantic effects
+acceptance_criteria:
+  - A minimal reusable effect, step, and trampoline abstraction exists under the application layer.
+  - A representative non-hot-path session analysis workflow is expressed as pure steps and interpreted by a shell-provided interpreter.
+  - Tests cover successful execution, interpreter failure propagation, and interpreter substitution.
+  - Documentation explains default exclusion of hot-path forwarding, streaming loops, and ring-buffer internals.
+  - Existing proxy hot-path and ring-buffer code is not routed through the new trampoline.
+non_goals:
+  - Refactor the full audit persistence path.
+  - Add the trampoline to ring-buffer writes or streaming body loops.
+  - Replace Tokio, Axum, or EventCore.
+architecture_impacts:
+  - Adds an application-layer orchestration primitive that keeps effects as data and IO in interpreters.
+  - Documents when to use the trampoline and when performance islands should remain direct imperative code.
+test_trace_ids:
+  - successful-session-analysis:tests/application_trampoline.rs::session_analysis_workflow_completes_through_interpreted_effects
+  - interpreter-failure:tests/application_trampoline.rs::interpreter_failure_stops_the_trampoline
+  - substitute-interpreter:tests/application_trampoline.rs::session_analysis_workflow_runs_with_substitute_interpreter

--- a/.codex/test-lists/issue-188.md
+++ b/.codex/test-lists/issue-188.md
@@ -4,6 +4,7 @@
 - `tests/application_trampoline.rs::interpreter_failure_stops_the_trampoline`
 - `tests/application_trampoline.rs::session_analysis_workflow_runs_with_substitute_interpreter`
 - `tests/application_trampoline.rs::session_event_count_enforces_positive_boundary`
+- `cargo test --test application_trampoline`
 - `just test-adversary ISSUE=188`
 - `just fitness`
 - `just ci-rust`

--- a/.codex/test-lists/issue-188.md
+++ b/.codex/test-lists/issue-188.md
@@ -1,0 +1,9 @@
+# Issue 188 Test List
+
+- `tests/application_trampoline.rs::session_analysis_workflow_completes_through_interpreted_effects`
+- `tests/application_trampoline.rs::interpreter_failure_stops_the_trampoline`
+- `tests/application_trampoline.rs::session_analysis_workflow_runs_with_substitute_interpreter`
+- `tests/application_trampoline.rs::session_event_count_enforces_positive_boundary`
+- `just test-adversary ISSUE=188`
+- `just fitness`
+- `just ci-rust`

--- a/docs/guardrails/effect-step-trampoline.md
+++ b/docs/guardrails/effect-step-trampoline.md
@@ -35,6 +35,18 @@ Use this pattern for:
 
 This pattern MUST NOT be used inside measured hot-path forwarding or streaming loops unless benchmarks show the overhead is acceptable.
 
+The reusable application-layer primitive lives in `src/application/trampoline.rs`.
+Workflows MAY expose semantic effect enums and observation enums, then run them
+through a shell-owned interpreter. `src/application/session_analysis.rs` is the
+canonical small example: the workflow requests session-fact loading, analysis
+request persistence, and telemetry as effects, while the interpreter remains
+responsible for IO.
+
+Ring-buffer internals, per-chunk streaming loops, and hot-path forwarding MUST
+continue to use their documented performance-island APIs by default. Route those
+paths through the trampoline only after benchmark evidence is added to the
+relevant performance-island documentation.
+
 ## Enforcement
 
 - Architecture review against `docs/architecture/ARCHITECTURE.md`.

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -4,5 +4,12 @@
 //! domain logic and infrastructure components.
 
 pub mod app;
+pub mod session_analysis;
+pub mod trampoline;
 
 pub use app::Application;
+pub use session_analysis::{
+    SessionAnalysisEffect, SessionAnalysisObservation, SessionAnalysisResult,
+    SessionAnalysisWorkflow, SessionEventCount,
+};
+pub use trampoline::{run_trampoline, EffectInterpreter, Step, StepWorkflow, TrampolineError};

--- a/src/application/session_analysis.rs
+++ b/src/application/session_analysis.rs
@@ -1,0 +1,129 @@
+//! Non-hot-path session analysis workflow expressed as pure steps.
+
+use crate::{
+    application::trampoline::{Step, StepWorkflow},
+    domain::{identifiers::AnalysisId, session::SessionId},
+};
+use nutype::nutype;
+
+#[nutype(validate(greater = 0), derive(Debug, Clone, Copy, PartialEq, Eq, Hash))]
+pub struct SessionEventCount(u64);
+
+/// Effects requested by session-analysis orchestration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SessionAnalysisEffect {
+    LoadSessionFacts {
+        session_id: SessionId,
+    },
+    RecordAnalysisRequested {
+        session_id: SessionId,
+        analysis_id: AnalysisId,
+        event_count: SessionEventCount,
+    },
+    EmitTelemetry {
+        analysis_id: AnalysisId,
+        event_count: SessionEventCount,
+    },
+}
+
+/// Observations returned by a session-analysis interpreter.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SessionAnalysisObservation {
+    SessionFactsLoaded { event_count: SessionEventCount },
+    AnalysisRequestRecorded,
+    TelemetryEmitted,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionAnalysisResult {
+    pub session_id: SessionId,
+    pub analysis_id: AnalysisId,
+    pub event_count: SessionEventCount,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum SessionAnalysisError {
+    #[error("session analysis workflow received an unexpected observation")]
+    UnexpectedObservation,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum SessionAnalysisState {
+    Ready,
+    LoadingFacts,
+    RecordingRequest { event_count: SessionEventCount },
+    EmittingTelemetry { event_count: SessionEventCount },
+    Complete,
+}
+
+/// Session analysis is non-hot-path orchestration and can use the trampoline.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionAnalysisWorkflow {
+    session_id: SessionId,
+    analysis_id: AnalysisId,
+    state: SessionAnalysisState,
+}
+
+impl SessionAnalysisWorkflow {
+    pub fn new(session_id: SessionId, analysis_id: AnalysisId) -> Self {
+        Self {
+            session_id,
+            analysis_id,
+            state: SessionAnalysisState::Ready,
+        }
+    }
+}
+
+impl StepWorkflow for SessionAnalysisWorkflow {
+    type Effect = SessionAnalysisEffect;
+    type Error = SessionAnalysisError;
+    type Observation = SessionAnalysisObservation;
+    type Output = SessionAnalysisResult;
+
+    fn next_step(
+        &mut self,
+        observation: Option<Self::Observation>,
+    ) -> Step<Self::Effect, Self::Output, Self::Error> {
+        match (self.state.clone(), observation) {
+            (SessionAnalysisState::Ready, None) => {
+                self.state = SessionAnalysisState::LoadingFacts;
+                Step::Effect(SessionAnalysisEffect::LoadSessionFacts {
+                    session_id: self.session_id.clone(),
+                })
+            }
+            (
+                SessionAnalysisState::LoadingFacts,
+                Some(SessionAnalysisObservation::SessionFactsLoaded { event_count }),
+            ) => {
+                self.state = SessionAnalysisState::RecordingRequest { event_count };
+                Step::Effect(SessionAnalysisEffect::RecordAnalysisRequested {
+                    session_id: self.session_id.clone(),
+                    analysis_id: self.analysis_id.clone(),
+                    event_count,
+                })
+            }
+            (
+                SessionAnalysisState::RecordingRequest { event_count },
+                Some(SessionAnalysisObservation::AnalysisRequestRecorded),
+            ) => {
+                self.state = SessionAnalysisState::EmittingTelemetry { event_count };
+                Step::Effect(SessionAnalysisEffect::EmitTelemetry {
+                    analysis_id: self.analysis_id.clone(),
+                    event_count,
+                })
+            }
+            (
+                SessionAnalysisState::EmittingTelemetry { event_count },
+                Some(SessionAnalysisObservation::TelemetryEmitted),
+            ) => {
+                self.state = SessionAnalysisState::Complete;
+                Step::Complete(SessionAnalysisResult {
+                    session_id: self.session_id.clone(),
+                    analysis_id: self.analysis_id.clone(),
+                    event_count,
+                })
+            }
+            _ => Step::Failed(SessionAnalysisError::UnexpectedObservation),
+        }
+    }
+}

--- a/src/application/trampoline.rs
+++ b/src/application/trampoline.rs
@@ -1,0 +1,72 @@
+//! Reusable step-trampoline primitives for application orchestration.
+//!
+//! Workflows describe effects as data. Interpreters perform IO in the
+//! imperative shell and feed observations back into the workflow.
+
+use async_trait::async_trait;
+
+/// A workflow step either requests an effect, completes, or fails.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Step<Effect, Output, Error> {
+    Effect(Effect),
+    Complete(Output),
+    Failed(Error),
+}
+
+/// Pure workflow state machine driven by observations from an interpreter.
+pub trait StepWorkflow {
+    type Effect;
+    type Error;
+    type Observation;
+    type Output;
+
+    fn next_step(
+        &mut self,
+        observation: Option<Self::Observation>,
+    ) -> Step<Self::Effect, Self::Output, Self::Error>;
+}
+
+/// Interpreter owned by the imperative shell.
+#[async_trait]
+pub trait EffectInterpreter<Effect> {
+    type Error;
+    type Observation;
+
+    async fn interpret(&mut self, effect: Effect) -> Result<Self::Observation, Self::Error>;
+}
+
+/// Error returned by the trampoline when workflow or interpreter execution fails.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum TrampolineError<WorkflowError, InterpreterError> {
+    #[error("workflow failed: {0}")]
+    Workflow(WorkflowError),
+    #[error("interpreter failed: {0}")]
+    Interpreter(InterpreterError),
+}
+
+/// Run a workflow by interpreting each requested effect until it completes.
+pub async fn run_trampoline<Workflow, Interpreter>(
+    workflow: &mut Workflow,
+    interpreter: &mut Interpreter,
+) -> Result<Workflow::Output, TrampolineError<Workflow::Error, Interpreter::Error>>
+where
+    Workflow: StepWorkflow,
+    Interpreter: EffectInterpreter<Workflow::Effect, Observation = Workflow::Observation>,
+{
+    let mut observation = None;
+
+    loop {
+        match workflow.next_step(observation.take()) {
+            Step::Effect(effect) => {
+                observation = Some(
+                    interpreter
+                        .interpret(effect)
+                        .await
+                        .map_err(TrampolineError::Interpreter)?,
+                );
+            }
+            Step::Complete(output) => return Ok(output),
+            Step::Failed(error) => return Err(TrampolineError::Workflow(error)),
+        }
+    }
+}

--- a/tests/application_trampoline.rs
+++ b/tests/application_trampoline.rs
@@ -1,0 +1,227 @@
+use async_trait::async_trait;
+use union_square::{
+    application::{
+        run_trampoline, EffectInterpreter, SessionAnalysisEffect, SessionAnalysisObservation,
+        SessionAnalysisResult, SessionAnalysisWorkflow, SessionEventCount, TrampolineError,
+    },
+    domain::{identifiers::AnalysisId, session::SessionId},
+};
+
+#[derive(Default)]
+struct RecordingInterpreter {
+    effects: Vec<SessionAnalysisEffect>,
+}
+
+#[async_trait]
+impl EffectInterpreter<SessionAnalysisEffect> for RecordingInterpreter {
+    type Error = &'static str;
+    type Observation = SessionAnalysisObservation;
+
+    async fn interpret(
+        &mut self,
+        effect: SessionAnalysisEffect,
+    ) -> Result<Self::Observation, Self::Error> {
+        self.effects.push(effect.clone());
+
+        Ok(match effect {
+            SessionAnalysisEffect::LoadSessionFacts { .. } => {
+                SessionAnalysisObservation::SessionFactsLoaded {
+                    event_count: SessionEventCount::try_new(3).unwrap(),
+                }
+            }
+            SessionAnalysisEffect::RecordAnalysisRequested { .. } => {
+                SessionAnalysisObservation::AnalysisRequestRecorded
+            }
+            SessionAnalysisEffect::EmitTelemetry { .. } => {
+                SessionAnalysisObservation::TelemetryEmitted
+            }
+        })
+    }
+}
+
+struct FailingInterpreter {
+    effects: Vec<SessionAnalysisEffect>,
+    event_count: SessionEventCount,
+}
+
+impl FailingInterpreter {
+    fn new(event_count: SessionEventCount) -> Self {
+        Self {
+            effects: Vec::new(),
+            event_count,
+        }
+    }
+}
+
+#[async_trait]
+impl EffectInterpreter<SessionAnalysisEffect> for FailingInterpreter {
+    type Error = &'static str;
+    type Observation = SessionAnalysisObservation;
+
+    async fn interpret(
+        &mut self,
+        effect: SessionAnalysisEffect,
+    ) -> Result<Self::Observation, Self::Error> {
+        self.effects.push(effect.clone());
+
+        match effect {
+            SessionAnalysisEffect::LoadSessionFacts { .. } => {
+                Ok(SessionAnalysisObservation::SessionFactsLoaded {
+                    event_count: self.event_count,
+                })
+            }
+            SessionAnalysisEffect::RecordAnalysisRequested { .. } => Err("record failed"),
+            SessionAnalysisEffect::EmitTelemetry { .. } => {
+                Ok(SessionAnalysisObservation::TelemetryEmitted)
+            }
+        }
+    }
+}
+
+struct SubstituteInterpreter {
+    effects: Vec<SessionAnalysisEffect>,
+    event_count: SessionEventCount,
+}
+
+impl SubstituteInterpreter {
+    fn new(event_count: SessionEventCount) -> Self {
+        Self {
+            effects: Vec::new(),
+            event_count,
+        }
+    }
+}
+
+#[async_trait]
+impl EffectInterpreter<SessionAnalysisEffect> for SubstituteInterpreter {
+    type Error = &'static str;
+    type Observation = SessionAnalysisObservation;
+
+    async fn interpret(
+        &mut self,
+        effect: SessionAnalysisEffect,
+    ) -> Result<Self::Observation, Self::Error> {
+        self.effects.push(effect.clone());
+
+        Ok(match effect {
+            SessionAnalysisEffect::LoadSessionFacts { .. } => {
+                SessionAnalysisObservation::SessionFactsLoaded {
+                    event_count: self.event_count,
+                }
+            }
+            SessionAnalysisEffect::RecordAnalysisRequested { .. } => {
+                SessionAnalysisObservation::AnalysisRequestRecorded
+            }
+            SessionAnalysisEffect::EmitTelemetry { .. } => {
+                SessionAnalysisObservation::TelemetryEmitted
+            }
+        })
+    }
+}
+
+#[tokio::test]
+async fn session_analysis_workflow_completes_through_interpreted_effects() {
+    let session_id = SessionId::generate();
+    let analysis_id = AnalysisId::generate();
+    let event_count = SessionEventCount::try_new(3).unwrap();
+    let mut workflow = SessionAnalysisWorkflow::new(session_id.clone(), analysis_id.clone());
+    let mut interpreter = RecordingInterpreter::default();
+
+    let result = run_trampoline(&mut workflow, &mut interpreter).await;
+
+    assert_eq!(
+        result,
+        Ok(SessionAnalysisResult {
+            session_id: session_id.clone(),
+            analysis_id: analysis_id.clone(),
+            event_count,
+        })
+    );
+    assert_eq!(
+        interpreter.effects,
+        vec![
+            SessionAnalysisEffect::LoadSessionFacts {
+                session_id: session_id.clone(),
+            },
+            SessionAnalysisEffect::RecordAnalysisRequested {
+                session_id,
+                analysis_id: analysis_id.clone(),
+                event_count,
+            },
+            SessionAnalysisEffect::EmitTelemetry {
+                analysis_id,
+                event_count,
+            },
+        ]
+    );
+    assert!(!matches!(result, Err(TrampolineError::Interpreter(_))));
+}
+
+#[tokio::test]
+async fn interpreter_failure_stops_the_trampoline() {
+    let session_id = SessionId::generate();
+    let analysis_id = AnalysisId::generate();
+    let event_count = SessionEventCount::try_new(2).unwrap();
+    let mut workflow = SessionAnalysisWorkflow::new(session_id.clone(), analysis_id.clone());
+    let mut interpreter = FailingInterpreter::new(event_count);
+
+    let result = run_trampoline(&mut workflow, &mut interpreter).await;
+
+    assert_eq!(result, Err(TrampolineError::Interpreter("record failed")));
+    assert_eq!(
+        interpreter.effects,
+        vec![
+            SessionAnalysisEffect::LoadSessionFacts {
+                session_id: session_id.clone(),
+            },
+            SessionAnalysisEffect::RecordAnalysisRequested {
+                session_id,
+                analysis_id,
+                event_count,
+            },
+        ]
+    );
+}
+
+#[tokio::test]
+async fn session_analysis_workflow_runs_with_substitute_interpreter() {
+    let session_id = SessionId::generate();
+    let analysis_id = AnalysisId::generate();
+    let event_count = SessionEventCount::try_new(7).unwrap();
+    let mut workflow = SessionAnalysisWorkflow::new(session_id.clone(), analysis_id.clone());
+    let mut interpreter = SubstituteInterpreter::new(event_count);
+
+    let result = run_trampoline(&mut workflow, &mut interpreter).await;
+
+    assert_eq!(
+        result,
+        Ok(SessionAnalysisResult {
+            session_id: session_id.clone(),
+            analysis_id: analysis_id.clone(),
+            event_count,
+        })
+    );
+    assert_eq!(
+        interpreter.effects,
+        vec![
+            SessionAnalysisEffect::LoadSessionFacts {
+                session_id: session_id.clone(),
+            },
+            SessionAnalysisEffect::RecordAnalysisRequested {
+                session_id,
+                analysis_id: analysis_id.clone(),
+                event_count,
+            },
+            SessionAnalysisEffect::EmitTelemetry {
+                analysis_id,
+                event_count,
+            },
+        ]
+    );
+}
+
+#[test]
+fn session_event_count_enforces_positive_boundary() {
+    assert!(SessionEventCount::try_new(1).is_ok());
+    assert!(SessionEventCount::try_new(0).is_err());
+}


### PR DESCRIPTION
## Summary
- add reusable application-layer step/trampoline primitives with shell-owned interpreters
- add a non-hot-path session analysis workflow using semantic effects and observations
- document hot-path, streaming, and ring-buffer exclusion by default

## Tests
- cargo test --test application_trampoline
- just test-adversary ISSUE=188
- just fitness
- just ci-rust
- just ast-grep

## Codex Workflow Evidence
- Issue: #188
- State: pr_ready
- Spec: .codex/specs/issue-188.yaml
- Ledger: local .codex/state/issue-188.json

Closes #188

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a step-based workflow orchestration framework with external effect interpretation.
  * Added a session analysis workflow that runs multi-step session analysis and returns structured results.

* **Documentation**
  * Added guidance and guardrails for the orchestration pattern, performance guidance, and acceptance criteria.

* **Tests**
  * Added tests covering success, interpreter failure, interpreter substitution, and event-count validation.

* **Chores**
  * Added a test-run list for reproducible test commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->