### PR TITLE
fix(codex): stabilize workflow smoke tests

### DIFF
--- a/.agents/skills/feature-delivery/SKILL.md
+++ b/.agents/skills/feature-delivery/SKILL.md
@@ -12,4 +12,9 @@ Workflow:
 - Use `just agent` to maintain the issue ledger.
 - Write one red outside-in test at a time.
 - Run `just test-adversary ISSUE=<number>` and `just fitness` before commit readiness.
+- When running expert review agents, prefer narrow current-diff context: use
+  `fork_turns: "none"` and include the repository path, issue number, changed
+  files or `git diff` scope, and an instruction to ignore unrelated prior
+  conversation context. Avoid full-history forks for review-only tasks unless
+  the review explicitly depends on previous conversation decisions.
 - Export PR evidence with `just agent export-pr-summary <number>`.

--- a/.codex/hooks/test-hooks.sh
+++ b/.codex/hooks/test-hooks.sh
@@ -1,16 +1,42 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ -e .codex/state || -e .codex/specs/issue-217.yaml ]]; then
-  echo "refusing to run hook smoke tests with existing issue 217 state/spec" >&2
-  exit 1
-fi
+backup_dir="$(mktemp -d)"
+had_state=0
+had_issue_217_spec=0
 
-cleanup() {
+restore_workflow_state() {
+  local exit_code=$?
+
   rm -rf .codex/state
   rm -f .codex/specs/issue-217.yaml
+
+  if [[ "$had_state" == "1" ]]; then
+    mkdir -p .codex
+    mv "$backup_dir/state" .codex/state
+  fi
+
+  if [[ "$had_issue_217_spec" == "1" ]]; then
+    mkdir -p .codex/specs
+    mv "$backup_dir/issue-217.yaml" .codex/specs/issue-217.yaml
+  fi
+
+  rm -rf "$backup_dir"
+  exit "$exit_code"
 }
-trap cleanup EXIT
+trap restore_workflow_state EXIT
+
+if [[ -e .codex/state ]]; then
+  mv .codex/state "$backup_dir/state"
+  had_state=1
+fi
+
+if [[ -e .codex/specs/issue-217.yaml ]]; then
+  mv .codex/specs/issue-217.yaml "$backup_dir/issue-217.yaml"
+  had_issue_217_spec=1
+fi
+
+mkdir -p .codex/specs
 
 cat > .codex/specs/issue-217.yaml <<'SPEC'
 issue: 217

--- a/.codex/specs/issue-226.yaml
+++ b/.codex/specs/issue-226.yaml
@@ -1,0 +1,38 @@
+issue: 226
+goal: Stabilize Codex workflow smoke tests and review guidance so active issue delivery does not require manual workarounds.
+examples:
+  - id: hooks-preserve-active-ledger
+    name: hook smoke tests preserve an active issue ledger
+    given:
+      - an active Codex issue ledger already exists under .codex/state
+      - hook smoke tests need their own temporary issue ledger
+    when:
+      - the hook smoke tests run
+    then:
+      - the smoke tests pass
+      - the original active issue ledger is restored
+      - temporary smoke-test state is removed
+  - id: review-agents-use-narrow-context
+    name: review guidance avoids stale context leakage
+    given:
+      - a contributor needs architecture, design, or test coverage review
+      - prior conversation context may contain unrelated tasks
+    when:
+      - the contributor invokes review agents
+    then:
+      - the guidance directs reviewers to use current repository diff context
+      - the guidance avoids inheriting unrelated full conversation history by default
+acceptance_criteria:
+  - .codex/hooks/test-hooks.sh can run while .codex/state contains an active issue ledger.
+  - The hook smoke test restores any pre-existing .codex/state and .codex/specs/issue-217.yaml content.
+  - just test-hooks passes during an active issue workflow.
+  - Review guidance documents narrow current-diff review invocation for expert agents.
+non_goals:
+  - Changing Codex runtime context management.
+  - Changing GitHub branch protection rules.
+  - Refactoring the whole local workflow harness.
+architecture_impacts:
+  - none
+test_trace_ids:
+  - hooks-preserve-active-ledger:.codex/hooks/test-hooks.sh
+  - review-agents-use-narrow-context:.agents/skills/feature-delivery/SKILL.md

--- a/.codex/test-lists/issue-226.md
+++ b/.codex/test-lists/issue-226.md
@@ -1,0 +1,6 @@
+# Issue 226 Test List
+
+- `just test-hooks`
+- `just test-adversary ISSUE=226`
+- `just fitness`
+- `just ci-rust`

--- a/tools/us-test-adversary/fixtures/non-rust/test-hooks.sh
+++ b/tools/us-test-adversary/fixtures/non-rust/test-hooks.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+echo "shell workflow smoke test fixture"

--- a/tools/us-test-adversary/src/main.rs
+++ b/tools/us-test-adversary/src/main.rs
@@ -113,16 +113,23 @@ fn validate_trace(root: &Path, trace: &str) -> Result<(), String> {
         .map_or(test_ref, |(path, _test_name)| path);
     reject_escaping_path(test_path)?;
     let full_path = root.join(test_path);
+
+    if !is_rust_test_path(test_path) {
+        fs::metadata(&full_path).map_err(|error| {
+            format!(
+                "failed to read traced test {}: {error}",
+                full_path.display()
+            )
+        })?;
+        return Ok(());
+    }
+
     let test_text = fs::read_to_string(&full_path).map_err(|error| {
         format!(
             "failed to read traced test {}: {error}",
             full_path.display()
         )
     })?;
-
-    if !is_rust_test_path(test_path) {
-        return Ok(());
-    }
 
     if !contains_test_function(&test_text)? {
         return Err(format!(
@@ -293,6 +300,20 @@ mod tests {
     fn non_rust_trace_targets_must_exist_but_do_not_parse_as_rust() {
         validate_trace(Path::new("."), "example:fixtures/non-rust/test-hooks.sh")
             .expect("non-Rust trace target should be accepted after existence check");
+    }
+
+    #[test]
+    fn non_utf8_trace_targets_do_not_parse_as_rust() {
+        let root =
+            std::env::temp_dir().join(format!("us-test-adversary-non-utf8-{}", std::process::id()));
+        std::fs::create_dir_all(&root).expect("temp fixture directory should be created");
+        std::fs::write(root.join("trace.bin"), [0xff, 0xfe])
+            .expect("binary fixture should be written");
+
+        validate_trace(&root, "example:trace.bin")
+            .expect("non-Rust binary trace should only require existence");
+
+        std::fs::remove_dir_all(root).expect("temp fixture directory should be removed");
     }
 
     #[test]

--- a/tools/us-test-adversary/src/main.rs
+++ b/tools/us-test-adversary/src/main.rs
@@ -120,6 +120,10 @@ fn validate_trace(root: &Path, trace: &str) -> Result<(), String> {
         )
     })?;
 
+    if !is_rust_test_path(test_path) {
+        return Ok(());
+    }
+
     if !contains_test_function(&test_text)? {
         return Err(format!(
             "traced file `{test_path}` does not contain a Rust test"
@@ -131,6 +135,13 @@ fn validate_trace(root: &Path, trace: &str) -> Result<(), String> {
         ));
     }
     Ok(())
+}
+
+fn is_rust_test_path(test_path: &str) -> bool {
+    Path::new(test_path)
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| extension == "rs")
 }
 
 fn contains_test_function(test_text: &str) -> Result<bool, String> {
@@ -276,6 +287,12 @@ mod tests {
             .expect_err("path traversal is rejected");
 
         assert!(error.contains("must stay inside the repository"));
+    }
+
+    #[test]
+    fn non_rust_trace_targets_must_exist_but_do_not_parse_as_rust() {
+        validate_trace(Path::new("."), "example:fixtures/non-rust/test-hooks.sh")
+            .expect("non-Rust trace target should be accepted after existence check");
     }
 
     #[test]

--- a/tools/us-test-adversary/src/main.rs
+++ b/tools/us-test-adversary/src/main.rs
@@ -115,12 +115,18 @@ fn validate_trace(root: &Path, trace: &str) -> Result<(), String> {
     let full_path = root.join(test_path);
 
     if !is_rust_test_path(test_path) {
-        fs::metadata(&full_path).map_err(|error| {
+        let metadata = fs::metadata(&full_path).map_err(|error| {
             format!(
                 "failed to read traced test {}: {error}",
                 full_path.display()
             )
         })?;
+        if !metadata.is_file() {
+            return Err(format!(
+                "traced target `{}` must be a file",
+                full_path.display()
+            ));
+        }
         return Ok(());
     }
 
@@ -313,6 +319,22 @@ mod tests {
         validate_trace(&root, "example:trace.bin")
             .expect("non-Rust binary trace should only require existence");
 
+        std::fs::remove_dir_all(root).expect("temp fixture directory should be removed");
+    }
+
+    #[test]
+    fn non_rust_trace_targets_must_be_files() {
+        let root = std::env::temp_dir().join(format!(
+            "us-test-adversary-directory-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(root.join("trace-directory"))
+            .expect("temp fixture directory should be created");
+
+        let error = validate_trace(&root, "example:trace-directory")
+            .expect_err("directory trace target should be rejected");
+
+        assert!(error.contains("must be a file"));
         std::fs::remove_dir_all(root).expect("temp fixture directory should be removed");
     }
 


### PR DESCRIPTION
## Summary
- preserve and restore active `.codex/state` plus any existing issue-217 spec while hook smoke tests run
- allow `us-test-adversary` to validate non-Rust trace targets by existence instead of parsing them as Rust
- document narrow current-diff review-agent invocation in the feature-delivery skill

## Tests
- `just test-hooks`
- `cargo test --manifest-path tools/us-test-adversary/Cargo.toml non_rust_trace_targets_must_exist_but_do_not_parse_as_rust`
- `just test-adversary ISSUE=226`
- `just fitness`
- `just ci-rust`
- `just ast-grep`

## Codex Workflow Evidence
- Issue: #226
- State: `pr_ready`
- Spec: `.codex/specs/issue-226.yaml`
- Ledger: local `.codex/state/issue-226.json`

Closes #226


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Test framework now accepts non-Rust test targets (including binary/non-UTF8) without attempting Rust parsing.

* **Bug Fixes**
  * Hook tests now back up and restore existing test state so they can run alongside active workflows safely.

* **Documentation**
  * Updated review guidance to scope expert reviews to current repo context and avoid inheriting unrelated history.

* **Tests**
  * Added specs, test lists, and a lightweight shell fixture to exercise workflow stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->