### PR TITLE
ci: centralize security and architecture checks

### DIFF
--- a/.codex/hooks/test-hooks.sh
+++ b/.codex/hooks/test-hooks.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 backup_dir="$(mktemp -d)"
+repo_root="$(pwd)"
 had_state=0
 had_issue_217_spec=0
 
@@ -84,6 +85,30 @@ do
 done
 
 printf '%s' '{"tool_input":{"command":"gh pr create --fill"}}' | .codex/hooks/pre-tool-use.sh >/dev/null
+
+conflict_repo="$backup_dir/conflict-repo"
+mkdir "$conflict_repo"
+git -C "$conflict_repo" init -q
+git -C "$conflict_repo" config user.email codex@example.invalid
+git -C "$conflict_repo" config user.name Codex
+{
+  printf '%s\n' '<<<<<<< HEAD'
+  printf '%s\n' 'left'
+  printf '%s\n' '======='
+  printf '%s\n' 'right'
+  printf '%s\n' '>>>>>>> branch'
+} > "$conflict_repo/conflict.txt"
+git -C "$conflict_repo" add conflict.txt
+staged_conflict_blob_before="$(git -C "$conflict_repo" rev-parse :conflict.txt)"
+if (cd "$conflict_repo" && "$repo_root/tools/check-merge-conflict-markers.sh") 2>/dev/null; then
+  echo "expected merge conflict marker check to fail on staged markers" >&2
+  exit 1
+fi
+staged_conflict_blob_after="$(git -C "$conflict_repo" rev-parse :conflict.txt)"
+if [[ "$staged_conflict_blob_before" != "$staged_conflict_blob_after" ]]; then
+  echo "expected merge conflict marker check to leave the staged blob unchanged" >&2
+  exit 1
+fi
 
 rm -f .codex/specs/issue-217.yaml
 if printf '%s' '{"tool_input":{"command":"git commit -m test"}}' | .codex/hooks/pre-tool-use.sh 2>/dev/null; then

--- a/.codex/hooks/test-hooks.sh
+++ b/.codex/hooks/test-hooks.sh
@@ -100,8 +100,14 @@ git -C "$conflict_repo" config user.name Codex
 } > "$conflict_repo/conflict.txt"
 git -C "$conflict_repo" add conflict.txt
 staged_conflict_blob_before="$(git -C "$conflict_repo" rev-parse :conflict.txt)"
-if (cd "$conflict_repo" && "$repo_root/tools/check-merge-conflict-markers.sh") 2>/dev/null; then
+conflict_output="$(
+  cd "$conflict_repo" && "$repo_root/tools/check-merge-conflict-markers.sh" 2>&1
+)" && {
   echo "expected merge conflict marker check to fail on staged markers" >&2
+  exit 1
+}
+if ! grep -qi "merge conflict" <<<"$conflict_output"; then
+  echo "expected merge conflict marker check to report the failure" >&2
   exit 1
 fi
 staged_conflict_blob_after="$(git -C "$conflict_repo" rev-parse :conflict.txt)"

--- a/.codex/specs/issue-183.yaml
+++ b/.codex/specs/issue-183.yaml
@@ -33,6 +33,8 @@ examples:
 acceptance_criteria:
   - A shared just CI target includes Rust checks, architecture checks, dependency checks, and GitHub Actions security linting.
   - The GitHub Actions CI workflow delegates core checks to just targets instead of duplicating cargo command sequences.
+  - Third-party GitHub Actions are pinned to immutable SHAs, with documented exceptions only for GitHub-owned actions.
+  - Clippy guardrails explicitly deny unwrap, expect, panic, todo, unimplemented, unreachable, and debug-printing macros.
   - Ast-grep architecture rules include executable validation examples.
   - Lefthook merge-conflict detection fails when markers are staged and does not mutate files.
 non_goals:

--- a/.codex/specs/issue-183.yaml
+++ b/.codex/specs/issue-183.yaml
@@ -1,0 +1,47 @@
+issue: 183
+goal: Make the repository CI and hook command surface enforce architecture and workflow guardrails from shared task-runner targets.
+examples:
+  - id: shared-ci-contract
+    name: complete CI contract is exposed through just targets
+    given:
+      - contributors and GitHub Actions need the same canonical command surface
+      - architecture, dependency, and workflow-security checks are part of the documented CI contract
+    when:
+      - the complete CI command is inspected or run
+    then:
+      - the command includes formatting, clippy, type checks, tests, doctests, ast-grep, fitness, dependency audit, dependency policy, and GitHub Actions security linting
+      - GitHub Actions invokes the shared just targets for core checks instead of embedding raw cargo command sequences
+  - id: architecture-lint-validation
+    name: architecture lint rules have executable validation examples
+    given:
+      - ast-grep rules enforce architecture boundaries for production Rust code
+    when:
+      - the architecture lint validation command runs
+    then:
+      - rule tests verify forbidden production unwrap, expect, panic, and raw primitive domain state examples are rejected
+      - allowed test-only or non-domain examples remain accepted
+  - id: deterministic-hooks
+    name: hooks fail deterministically without mutating staged files
+    given:
+      - staged files may contain merge conflict markers
+      - pre-commit hooks must not rewrite staged content
+    when:
+      - lefthook runs its pre-commit checks
+    then:
+      - merge conflict markers cause a failing hook result
+      - hook commands report failures without modifying staged files
+acceptance_criteria:
+  - A shared just CI target includes Rust checks, architecture checks, dependency checks, and GitHub Actions security linting.
+  - The GitHub Actions CI workflow delegates core checks to just targets instead of duplicating cargo command sequences.
+  - Ast-grep architecture rules include executable validation examples.
+  - Lefthook merge-conflict detection fails when markers are staged and does not mutate files.
+non_goals:
+  - Refactoring existing product behavior.
+  - Fixing every historical architecture lint violation outside the targeted CI baseline.
+  - Adding architecture rules not already documented by the architecture source of truth or guardrails.
+architecture_impacts:
+  - Reinforces the documented architecture guardrails as executable CI and hook checks.
+test_trace_ids:
+  - shared-ci-contract:tests/ci_contract.rs::complete_ci_contract_includes_actions_security_linting
+  - architecture-lint-validation:tools/ast-grep/rule-tests/no-raw-primitive-domain-state-test.yml
+  - deterministic-hooks:tools/check-merge-conflict-markers.sh

--- a/.codex/test-lists/issue-183.md
+++ b/.codex/test-lists/issue-183.md
@@ -1,0 +1,8 @@
+# Issue 183 Test List
+
+- `cargo test --test ci_contract complete_ci_contract_includes_actions_security_linting`
+- `just ast-grep-test`
+- `just test-hooks`
+- `just test-adversary ISSUE=183`
+- `just fitness`
+- `just ci-rust`

--- a/.codex/test-lists/issue-183.md
+++ b/.codex/test-lists/issue-183.md
@@ -5,4 +5,5 @@
 - `just test-hooks`
 - `just test-adversary ISSUE=183`
 - `just fitness`
+- `just ci-security`
 - `just ci-rust`

--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -134,7 +134,7 @@ jobs:
       - name: Generate checksums file
         run: |
           cd artifacts
-          cat *.sha256 > checksums.txt
+          cat ./*.sha256 > checksums.txt
           echo "Checksums:"
           cat checksums.txt
 

--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -294,6 +294,11 @@ jobs:
           RELEASE_TAG: ${{ github.event.release.tag_name || github.event.inputs.tag_name }}
           REPOSITORY: ${{ github.repository }}
         run: |
+          if [[ -z "${RELEASE_TAG}" ]]; then
+            echo "tag_name input is required for workflow_dispatch"
+            exit 1
+          fi
+
           echo "Downloading release ${RELEASE_TAG}"
 
           # Download Linux x86_64 binary

--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -13,6 +13,9 @@ on:
 env:
   RUST_BACKTRACE: 1
 
+permissions:
+  contents: read
+
 jobs:
   build-binaries:
     name: Build ${{ matrix.target }}
@@ -199,8 +202,10 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Generate Homebrew formula
+        env:
+          VERSION: ${{ github.event.release.tag_name }}
+          REPOSITORY: ${{ github.repository }}
         run: |
-          VERSION="${{ github.event.release.tag_name }}"
           VERSION="${VERSION#v}"  # Remove 'v' prefix if present
 
           # Extract description from Cargo.toml
@@ -213,7 +218,7 @@ jobs:
           # Download checksums from the release
           echo "Downloading checksums from release..."
           curl -L -o checksums.txt \
-            "https://github.com/${{ github.repository }}/releases/download/v${VERSION}/checksums.txt" || true
+            "https://github.com/${REPOSITORY}/releases/download/v${VERSION}/checksums.txt" || true
 
           # Extract SHA256 values for each platform
           if [[ -f checksums.txt ]]; then
@@ -232,26 +237,26 @@ jobs:
           cat > union-square.rb << EOF
           class UnionSquare < Formula
             desc "${DESCRIPTION}"
-            homepage "https://github.com/${{ github.repository }}"
+            homepage "https://github.com/${REPOSITORY}"
             version "${VERSION}"
             license "MIT"
 
             on_macos do
               if Hardware::CPU.intel?
-                url "https://github.com/${{ github.repository }}/releases/download/v${VERSION}/union_square-x86_64-macos.tar.gz"
+                url "https://github.com/${REPOSITORY}/releases/download/v${VERSION}/union_square-x86_64-macos.tar.gz"
                 sha256 "${SHA256_X86_64_MACOS}"
               elsif Hardware::CPU.arm?
-                url "https://github.com/${{ github.repository }}/releases/download/v${VERSION}/union_square-aarch64-macos.tar.gz"
+                url "https://github.com/${REPOSITORY}/releases/download/v${VERSION}/union_square-aarch64-macos.tar.gz"
                 sha256 "${SHA256_AARCH64_MACOS}"
               end
             end
 
             on_linux do
               if Hardware::CPU.intel?
-                url "https://github.com/${{ github.repository }}/releases/download/v${VERSION}/union_square-x86_64-linux.tar.gz"
+                url "https://github.com/${REPOSITORY}/releases/download/v${VERSION}/union_square-x86_64-linux.tar.gz"
                 sha256 "${SHA256_X86_64_LINUX}"
               elsif Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-                url "https://github.com/${{ github.repository }}/releases/download/v${VERSION}/union_square-aarch64-linux.tar.gz"
+                url "https://github.com/${REPOSITORY}/releases/download/v${VERSION}/union_square-aarch64-linux.tar.gz"
                 sha256 "${SHA256_AARCH64_LINUX}"
               end
             end
@@ -285,17 +290,19 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Download and verify Linux binary
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name || github.event.inputs.tag_name }}
+          REPOSITORY: ${{ github.repository }}
         run: |
-          RELEASE_TAG="${{ github.event.release.tag_name || github.event.inputs.tag_name }}"
           echo "Downloading release ${RELEASE_TAG}"
 
           # Download Linux x86_64 binary
           curl -L -o union_square-x86_64-linux.tar.gz \
-            "https://github.com/${{ github.repository }}/releases/download/${RELEASE_TAG}/union_square-x86_64-linux.tar.gz"
+            "https://github.com/${REPOSITORY}/releases/download/${RELEASE_TAG}/union_square-x86_64-linux.tar.gz"
 
           # Download checksum
           curl -L -o union_square-x86_64-linux.tar.gz.sha256 \
-            "https://github.com/${{ github.repository }}/releases/download/${RELEASE_TAG}/union_square-x86_64-linux.tar.gz.sha256"
+            "https://github.com/${REPOSITORY}/releases/download/${RELEASE_TAG}/union_square-x86_64-linux.tar.gz.sha256"
 
           # Verify checksum
           echo "Verifying checksum..."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,12 @@ jobs:
           deps:
             - 'Cargo.toml'
             - 'Cargo.lock'
+            - 'deny.toml'
+            - 'Justfile'
+            - '.github/dependabot.yml'
+            - '.github/zizmor.yml'
+            - '.github/workflows/**'
+            - 'tools/ast-grep/**'
             - '.github/workflows/ci.yml'
           harness:
             - 'AGENTS.md'
@@ -142,28 +148,10 @@ jobs:
     - name: Install cargo-nextest
       run: cargo install cargo-nextest --locked
 
-    - name: Check formatting
-      run: just fmt-check
-
-    - name: Run clippy
-      run: just clippy
-
-    - name: Run tests with nextest
-      run: just test
+    - name: Run Rust CI contract
+      run: just ci-rust
       env:
         DATABASE_URL: postgres://postgres:postgres@localhost:5432/union_square
-
-    - name: Run doctests
-      run: just test-doc
-      env:
-        DATABASE_URL: postgres://postgres:postgres@localhost:5432/union_square
-
-    - name: Type check
-      run: just check
-
-    - name: Architecture fitness
-      run: just fitness
-      env:
         US_FITNESS_BASE_REF: origin/${{ github.base_ref || 'main' }}
 
   security:
@@ -190,8 +178,19 @@ jobs:
     - name: Install cargo-audit
       run: cargo install cargo-audit --locked
 
-    - name: Run security audit
-      run: just audit
+    - name: Install cargo-deny
+      run: cargo install cargo-deny --locked
+
+    - name: Install actionlint
+      uses: taiki-e/install-action@1329c298aa20c3257846c9b2e0e55967df3e3c37
+      with:
+        tool: actionlint
+
+    - name: Install zizmor
+      run: pipx install zizmor
+
+    - name: Run shared security checks
+      run: just ci-security
 
   coverage:
     name: Code Coverage
@@ -369,9 +368,11 @@ jobs:
 
     - name: Get baseline benchmark results
       if: github.event_name == 'pull_request'
+      env:
+        BASE_REF: ${{ github.base_ref }}
       run: |
-        git fetch origin ${{ github.base_ref }}
-        git checkout origin/${{ github.base_ref }}
+        git fetch origin "$BASE_REF"
+        git checkout "origin/$BASE_REF"
         cargo bench --bench proxy_performance -- --save-baseline base --sample-size 50
         git checkout -
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,15 +179,15 @@ jobs:
       run: cargo install cargo-audit --locked
 
     - name: Install cargo-deny
-      run: cargo install cargo-deny --locked
+      run: cargo install cargo-deny --version 0.19.4 --locked
 
     - name: Install actionlint
       uses: taiki-e/install-action@1329c298aa20c3257846c9b2e0e55967df3e3c37
       with:
-        tool: actionlint
+        tool: actionlint@1.7.7
 
     - name: Install zizmor
-      run: pipx install zizmor
+      run: pipx install 'zizmor==1.24.1'
 
     - name: Run shared security checks
       run: just ci-security

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,9 +182,15 @@ jobs:
       run: cargo install cargo-deny --version 0.19.4 --locked
 
     - name: Install actionlint
-      uses: taiki-e/install-action@1329c298aa20c3257846c9b2e0e55967df3e3c37
-      with:
-        tool: actionlint@1.7.7
+      env:
+        ACTIONLINT_VERSION: 1.7.7
+      run: |
+        curl -fsSLO "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+        curl -fsSLO "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_checksums.txt"
+        grep " actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz$" \
+          "actionlint_${ACTIONLINT_VERSION}_checksums.txt" | sha256sum -c -
+        tar -xzf "actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+        sudo install -m 0755 actionlint /usr/local/bin/actionlint
 
     - name: Install zizmor
       run: pipx install 'zizmor==1.24.1'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -406,10 +406,10 @@ jobs:
 
         if [ "$REGRESSION_FOUND" = true ]; then
           echo "Performance regression detected!"
-          echo "REGRESSION_DETECTED=true" >> $GITHUB_OUTPUT
+          echo "REGRESSION_DETECTED=true" >> "$GITHUB_OUTPUT"
         else
           echo "No significant regression detected"
-          echo "REGRESSION_DETECTED=false" >> $GITHUB_OUTPUT
+          echo "REGRESSION_DETECTED=false" >> "$GITHUB_OUTPUT"
         fi
 
         echo '```' > benchmark_report.md

--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -18,11 +18,8 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 # Allow one concurrent deployment
 concurrency:
@@ -32,6 +29,8 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -70,6 +69,9 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      pages: write
+      id-token: write
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,6 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        actions/*: ref-pin
+        "*": hash-pin

--- a/Justfile
+++ b/Justfile
@@ -64,18 +64,27 @@ audit:
     cargo audit
 
 deny:
-    cargo deny check
+    cargo deny check advisories bans licenses sources
+
+actions-security:
+    actionlint
+    zizmor --min-severity high .
+
+ci-security: audit deny actions-security
 
 ast-grep:
     files="$(git diff --name-only --diff-filter=ACMR; git diff --cached --name-only --diff-filter=ACMR)" \
-      && files="$(printf '%s\n' "$files" | sort -u | grep -E '\.rs$' | grep -Ev '^(tests/|benches/|tools/ast-grep/rules/rule-tests/)' || true)" \
+      && files="$(printf '%s\n' "$files" | sort -u | grep -E '\.rs$' | grep -Ev '^(tests/|benches/|tools/ast-grep/rules/rule-tests/|tools/ast-grep/rule-tests/)' || true)" \
       && if [ -n "$files" ]; then ast-grep scan $files; else echo "ast-grep skipped: no changed Rust source files"; fi
 
 ast-grep-branch:
     base_ref="${US_AST_GREP_BASE_REF:-${US_FITNESS_BASE_REF:-origin/main}}" \
       && if git rev-parse --verify "$base_ref" >/dev/null 2>&1; then files="$(git diff --name-only --diff-filter=ACMR "$base_ref"...HEAD)"; else files="$(git diff --name-only --diff-filter=ACMR; git diff --cached --name-only --diff-filter=ACMR)"; fi \
-      && files="$(printf '%s\n' "$files" | sort -u | grep -E '\.rs$' | grep -Ev '^(tests/|benches/|tools/ast-grep/rules/rule-tests/)' || true)" \
+      && files="$(printf '%s\n' "$files" | sort -u | grep -E '\.rs$' | grep -Ev '^(tests/|benches/|tools/ast-grep/rules/rule-tests/|tools/ast-grep/rule-tests/)' || true)" \
       && if [ -n "$files" ]; then ast-grep scan $files; else echo "ast-grep skipped: no changed Rust source files"; fi
+
+ast-grep-test:
+    ast-grep test --skip-snapshot-tests
 
 bench-quick:
     cargo test --test benchmark_validation
@@ -96,8 +105,10 @@ agent *ARGS:
 db-up:
     docker compose up -d postgres postgres-test
 
-ci-rust: fmt-check clippy clippy-tools check check-tools test-tools test-hooks test test-doc ast-grep-branch fitness
+ci-rust: fmt-check clippy clippy-tools check check-tools test-tools test-hooks test test-doc ast-grep-branch ast-grep-test fitness
 
-ci-harness: check-tools clippy-tools test-tools test-hooks legacy-harness-check ast-grep-branch fitness
+ci-harness: check-tools clippy-tools test-tools test-hooks legacy-harness-check ast-grep-branch ast-grep-test fitness
 
-ci-full: ci-rust audit deny build build-release bench-quick
+ci-full: ci-rust ci-security build build-release bench-quick
+
+ci: ci-full

--- a/Justfile
+++ b/Justfile
@@ -74,13 +74,13 @@ ci-security: audit deny actions-security
 
 ast-grep:
     files="$(git diff --name-only --diff-filter=ACMR; git diff --cached --name-only --diff-filter=ACMR)" \
-      && files="$(printf '%s\n' "$files" | sort -u | grep -E '\.rs$' | grep -Ev '^(tests/|benches/|tools/ast-grep/rules/rule-tests/|tools/ast-grep/rule-tests/)' || true)" \
+      && files="$(printf '%s\n' "$files" | sort -u | grep -E '\.rs$' | grep -Ev '^(tests/|benches/|tools/ast-grep/rule-tests/)' || true)" \
       && if [ -n "$files" ]; then ast-grep scan $files; else echo "ast-grep skipped: no changed Rust source files"; fi
 
 ast-grep-branch:
     base_ref="${US_AST_GREP_BASE_REF:-${US_FITNESS_BASE_REF:-origin/main}}" \
       && if git rev-parse --verify "$base_ref" >/dev/null 2>&1; then files="$(git diff --name-only --diff-filter=ACMR "$base_ref"...HEAD)"; else files="$(git diff --name-only --diff-filter=ACMR; git diff --cached --name-only --diff-filter=ACMR)"; fi \
-      && files="$(printf '%s\n' "$files" | sort -u | grep -E '\.rs$' | grep -Ev '^(tests/|benches/|tools/ast-grep/rules/rule-tests/|tools/ast-grep/rule-tests/)' || true)" \
+      && files="$(printf '%s\n' "$files" | sort -u | grep -E '\.rs$' | grep -Ev '^(tests/|benches/|tools/ast-grep/rule-tests/)' || true)" \
       && if [ -n "$files" ]; then ast-grep scan $files; else echo "ast-grep skipped: no changed Rust source files"; fi
 
 ast-grep-test:

--- a/deny.toml
+++ b/deny.toml
@@ -15,26 +15,28 @@ feature-depth = 1
 [advisories]
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
-vulnerability = "deny"
-unmaintained = "warn"
+ignore = [
+    { id = "RUSTSEC-2026-0098", reason = "rustls-webpki 0.101.7 is pinned by transitive aws-smithy-http-client rustls 0.21 support; revisit when AWS SDK drops the legacy rustls stack" },
+    { id = "RUSTSEC-2026-0099", reason = "rustls-webpki 0.101.7 is pinned by transitive aws-smithy-http-client rustls 0.21 support; revisit when AWS SDK drops the legacy rustls stack" },
+    { id = "RUSTSEC-2026-0104", reason = "rustls-webpki 0.101.7 is pinned by transitive aws-smithy-http-client rustls 0.21 support; project does not use CRL parsing directly" },
+]
+unmaintained = "workspace"
 yanked = "deny"
-notice = "warn"
 
 [licenses]
-unlicensed = "deny"
 allow = [
     "MIT",
     "Apache-2.0",
     "Apache-2.0 WITH LLVM-exception",
     "BSD-2-Clause",
     "BSD-3-Clause",
+    "CC0-1.0",
+    "CDLA-Permissive-2.0",
     "ISC",
+    "Unicode-3.0",
     "Unicode-DFS-2016",
+    "Zlib",
 ]
-deny = []
-copyleft = "warn"
-allow-osi-fsf-free = "either"
-default = "deny"
 confidence-threshold = 0.8
 
 [bans]

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -33,7 +33,7 @@ pre-commit:
         fi
 
     check-merge-conflict:
-      run: git diff --cached --name-only | xargs grep -l "<<<<<<< HEAD" || true
+      run: tools/check-merge-conflict-markers.sh
 
 commit-msg:
   commands:

--- a/sgconfig.yml
+++ b/sgconfig.yml
@@ -1,7 +1,7 @@
 ruleDirs:
   - tools/ast-grep/rules
 testConfigs:
-  - testDir: tools/ast-grep/rules/rule-tests
+  - testDir: tools/ast-grep/rule-tests
 ignores:
   - "**/*_tests.rs"
   - "**/*_test.rs"

--- a/tests/ci_contract.rs
+++ b/tests/ci_contract.rs
@@ -1,0 +1,77 @@
+use std::fs;
+
+#[test]
+fn complete_ci_contract_includes_actions_security_linting() {
+    let justfile = fs::read_to_string("Justfile").expect("Justfile should be readable");
+    let ci_workflow =
+        fs::read_to_string(".github/workflows/ci.yml").expect("CI workflow should be readable");
+
+    let ci_full = just_target_dependencies(&justfile, "ci-full");
+    for expected_target in [
+        "ci-rust",
+        "ci-security",
+        "build",
+        "build-release",
+        "bench-quick",
+    ] {
+        assert!(
+            ci_full.contains(&expected_target),
+            "ci-full should include {expected_target}"
+        );
+    }
+
+    let ci_rust = just_target_dependencies(&justfile, "ci-rust");
+    for expected_target in [
+        "fmt-check",
+        "clippy",
+        "clippy-tools",
+        "check",
+        "check-tools",
+        "test-tools",
+        "test-hooks",
+        "test",
+        "test-doc",
+        "ast-grep-branch",
+        "ast-grep-test",
+        "fitness",
+    ] {
+        assert!(
+            ci_rust.contains(&expected_target),
+            "ci-rust should include {expected_target}"
+        );
+    }
+
+    let ci_security = just_target_dependencies(&justfile, "ci-security");
+    for expected_target in ["audit", "deny", "actions-security"] {
+        assert!(
+            ci_security.contains(&expected_target),
+            "ci-security should include {expected_target}"
+        );
+    }
+
+    assert!(
+        justfile.contains("actionlint") && justfile.contains("zizmor --min-severity high ."),
+        "actions-security should run actionlint and high-severity zizmor"
+    );
+    assert!(
+        ci_workflow.contains("run: just ci-security"),
+        "CI security job should invoke the shared ci-security target"
+    );
+    assert!(
+        !ci_workflow.contains("run: just audit"),
+        "CI security job should not call audit directly and skip the rest of the shared security contract"
+    );
+}
+
+fn just_target_dependencies<'a>(justfile: &'a str, target: &str) -> Vec<&'a str> {
+    let prefix = format!("{target}:");
+    justfile
+        .lines()
+        .find(|line| line.starts_with(&prefix))
+        .unwrap_or_else(|| panic!("Justfile should define {target}"))
+        .split_once(':')
+        .expect("target line should contain a colon")
+        .1
+        .split_whitespace()
+        .collect()
+}

--- a/tests/ci_contract.rs
+++ b/tests/ci_contract.rs
@@ -50,20 +50,25 @@ fn complete_ci_contract_includes_actions_security_linting() -> Result<(), String
         );
     }
 
+    let actions_security = just_target_body(&justfile, "actions-security")?;
+    let security_job = workflow_job_body(&ci_workflow, "security")?;
+    let test_job = workflow_job_body(&ci_workflow, "test")?;
+
     assert!(
-        justfile.contains("actionlint") && justfile.contains("zizmor --min-severity high ."),
+        actions_security.contains("actionlint")
+            && actions_security.contains("zizmor --min-severity high ."),
         "actions-security should run actionlint and high-severity zizmor"
     );
     assert!(
-        ci_workflow.contains("run: just ci-security"),
+        security_job.contains("run: just ci-security"),
         "CI security job should invoke the shared ci-security target"
     );
     assert!(
-        ci_workflow.contains("run: just ci-rust"),
+        test_job.contains("run: just ci-rust"),
         "CI test job should invoke the shared ci-rust target"
     );
     assert!(
-        !ci_workflow.contains("run: just audit"),
+        !security_job.contains("run: just audit"),
         "CI security job should not call audit directly and skip the rest of the shared security contract"
     );
 
@@ -83,4 +88,59 @@ fn just_target_dependencies<'a>(justfile: &'a str, target: &str) -> Result<Vec<&
         .1
         .split_whitespace()
         .collect())
+}
+
+fn just_target_body<'a>(justfile: &'a str, target: &str) -> Result<&'a str, String> {
+    let prefix = format!("{target}:");
+    block_from_line(
+        justfile,
+        |line| line.starts_with(&prefix),
+        is_just_target_header,
+        || format!("Justfile should define {target}"),
+    )
+}
+
+fn workflow_job_body<'a>(workflow: &'a str, job: &str) -> Result<&'a str, String> {
+    let header = format!("  {job}:");
+    block_from_line(
+        workflow,
+        |line| line == header,
+        is_workflow_job_header,
+        || format!("CI workflow should define the {job} job"),
+    )
+}
+
+fn block_from_line(
+    text: &str,
+    is_start: impl Fn(&str) -> bool,
+    is_next_block: impl Fn(&str) -> bool,
+    missing_message: impl FnOnce() -> String,
+) -> Result<&str, String> {
+    let mut start = None;
+    let mut offset = 0;
+
+    for line in text.split_inclusive('\n') {
+        let trimmed_newline = line.trim_end_matches(['\r', '\n']);
+        if let Some(start_offset) = start {
+            if offset != start_offset && is_next_block(trimmed_newline) {
+                return Ok(&text[start_offset..offset]);
+            }
+        } else if is_start(trimmed_newline) {
+            start = Some(offset);
+        }
+
+        offset += line.len();
+    }
+
+    start
+        .map(|start_offset| &text[start_offset..])
+        .ok_or_else(missing_message)
+}
+
+fn is_just_target_header(line: &str) -> bool {
+    !line.is_empty() && !line.starts_with(' ') && !line.starts_with('\t') && line.contains(':')
+}
+
+fn is_workflow_job_header(line: &str) -> bool {
+    line.starts_with("  ") && !line.starts_with("    ") && line.ends_with(':')
 }

--- a/tests/ci_contract.rs
+++ b/tests/ci_contract.rs
@@ -1,12 +1,13 @@
 use std::fs;
 
 #[test]
-fn complete_ci_contract_includes_actions_security_linting() {
-    let justfile = fs::read_to_string("Justfile").expect("Justfile should be readable");
-    let ci_workflow =
-        fs::read_to_string(".github/workflows/ci.yml").expect("CI workflow should be readable");
+fn complete_ci_contract_includes_actions_security_linting() -> Result<(), String> {
+    let justfile = fs::read_to_string("Justfile")
+        .map_err(|error| format!("Justfile should be readable: {error}"))?;
+    let ci_workflow = fs::read_to_string(".github/workflows/ci.yml")
+        .map_err(|error| format!("CI workflow should be readable: {error}"))?;
 
-    let ci_full = just_target_dependencies(&justfile, "ci-full");
+    let ci_full = just_target_dependencies(&justfile, "ci-full")?;
     for expected_target in [
         "ci-rust",
         "ci-security",
@@ -20,7 +21,7 @@ fn complete_ci_contract_includes_actions_security_linting() {
         );
     }
 
-    let ci_rust = just_target_dependencies(&justfile, "ci-rust");
+    let ci_rust = just_target_dependencies(&justfile, "ci-rust")?;
     for expected_target in [
         "fmt-check",
         "clippy",
@@ -41,7 +42,7 @@ fn complete_ci_contract_includes_actions_security_linting() {
         );
     }
 
-    let ci_security = just_target_dependencies(&justfile, "ci-security");
+    let ci_security = just_target_dependencies(&justfile, "ci-security")?;
     for expected_target in ["audit", "deny", "actions-security"] {
         assert!(
             ci_security.contains(&expected_target),
@@ -58,20 +59,28 @@ fn complete_ci_contract_includes_actions_security_linting() {
         "CI security job should invoke the shared ci-security target"
     );
     assert!(
+        ci_workflow.contains("run: just ci-rust"),
+        "CI test job should invoke the shared ci-rust target"
+    );
+    assert!(
         !ci_workflow.contains("run: just audit"),
         "CI security job should not call audit directly and skip the rest of the shared security contract"
     );
+
+    Ok(())
 }
 
-fn just_target_dependencies<'a>(justfile: &'a str, target: &str) -> Vec<&'a str> {
+fn just_target_dependencies<'a>(justfile: &'a str, target: &str) -> Result<Vec<&'a str>, String> {
     let prefix = format!("{target}:");
-    justfile
+    let target_line = justfile
         .lines()
         .find(|line| line.starts_with(&prefix))
-        .unwrap_or_else(|| panic!("Justfile should define {target}"))
+        .ok_or_else(|| format!("Justfile should define {target}"))?;
+
+    Ok(target_line
         .split_once(':')
-        .expect("target line should contain a colon")
+        .ok_or_else(|| format!("{target} line should contain a colon"))?
         .1
         .split_whitespace()
-        .collect()
+        .collect())
 }

--- a/tools/ast-grep/rule-tests/no-expect-in-production-test.yml
+++ b/tools/ast-grep/rule-tests/no-expect-in-production-test.yml
@@ -1,0 +1,17 @@
+id: no-expect-in-production
+language: rust
+valid:
+  - |
+    #[cfg(test)]
+    mod tests {
+        #[test]
+        fn allows_expect_in_tests() {
+            let value = Some(42);
+            assert_eq!(value.expect("value"), 42);
+        }
+    }
+invalid:
+  - |
+    fn process(value: Option<i32>) -> i32 {
+        value.expect("value should exist")
+    }

--- a/tools/ast-grep/rule-tests/no-panic-macro-production-test.yml
+++ b/tools/ast-grep/rule-tests/no-panic-macro-production-test.yml
@@ -1,0 +1,19 @@
+id: no-panic-macro-production
+language: rust
+valid:
+  - |
+    #[cfg(test)]
+    mod tests {
+        #[test]
+        #[should_panic]
+        fn allows_panic_in_tests() {
+            panic!("expected panic in test");
+        }
+    }
+invalid:
+  - |
+    fn process(value: i32) {
+        if value < 0 {
+            panic!("value must be positive");
+        }
+    }

--- a/tools/ast-grep/rule-tests/no-raw-primitive-domain-state-test.yml
+++ b/tools/ast-grep/rule-tests/no-raw-primitive-domain-state-test.yml
@@ -19,3 +19,8 @@ invalid:
     struct SessionState {
         name: String,
     }
+  - |
+    struct SessionState {
+        id: SessionId,
+        name: String,
+    }

--- a/tools/ast-grep/rule-tests/no-raw-primitive-domain-state-test.yml
+++ b/tools/ast-grep/rule-tests/no-raw-primitive-domain-state-test.yml
@@ -24,3 +24,15 @@ invalid:
         id: SessionId,
         name: String,
     }
+  - |
+    struct SessionState {
+        signed_byte: i8,
+        signed_short: i16,
+        signed_large: i128,
+        signed_size: isize,
+        unsigned_byte: u8,
+        unsigned_short: u16,
+        unsigned_large: u128,
+        unsigned_size: usize,
+        marker: char,
+    }

--- a/tools/ast-grep/rule-tests/no-raw-primitive-domain-state-test.yml
+++ b/tools/ast-grep/rule-tests/no-raw-primitive-domain-state-test.yml
@@ -1,0 +1,21 @@
+id: no-raw-primitive-domain-state
+language: rust
+valid:
+  - |
+    struct SessionName(String);
+
+    struct SessionState {
+        name: SessionName,
+    }
+  - |
+    #[cfg(test)]
+    mod tests {
+        struct TestFixture {
+            name: String,
+        }
+    }
+invalid:
+  - |
+    struct SessionState {
+        name: String,
+    }

--- a/tools/ast-grep/rule-tests/no-unwrap-in-production-test.yml
+++ b/tools/ast-grep/rule-tests/no-unwrap-in-production-test.yml
@@ -1,0 +1,17 @@
+id: no-unwrap-in-production
+language: rust
+valid:
+  - |
+    #[cfg(test)]
+    mod tests {
+        #[test]
+        fn allows_unwrap_in_tests() {
+            let value = Some(42);
+            assert_eq!(value.unwrap(), 42);
+        }
+    }
+invalid:
+  - |
+    fn process(value: Option<i32>) -> i32 {
+        value.unwrap()
+    }

--- a/tools/ast-grep/rules/no-raw-primitive-domain-state.yml
+++ b/tools/ast-grep/rules/no-raw-primitive-domain-state.yml
@@ -6,15 +6,20 @@ files:
   - src/domain/**/*.rs
 rule:
   all:
-    - pattern: |
-        struct $NAME {
-          $FIELD: $TYPE,
-        }
+    - kind: field_declaration
+    - has:
+        field: type
+        any:
+          - kind: type_identifier
+            regex: "^String$"
+          - kind: primitive_type
+            regex: "^i32$|^i64$|^f32$|^f64$|^u32$|^u64$|^bool$"
+    - inside:
+        kind: field_declaration_list
+        inside:
+          kind: struct_item
     - not:
         inside:
           stopBy: end
           kind: mod_item
           regex: "mod (test.*|benchmarks|.*_test.*)"
-constraints:
-  TYPE:
-    regex: "^String$|^i32$|^i64$|^f32$|^f64$|^u32$|^u64$|^bool$"

--- a/tools/ast-grep/rules/no-raw-primitive-domain-state.yml
+++ b/tools/ast-grep/rules/no-raw-primitive-domain-state.yml
@@ -2,11 +2,19 @@ id: no-raw-primitive-domain-state
 language: rust
 severity: warning
 message: "Avoid using raw primitives for domain state. Consider newtypes with nutype."
+files:
+  - src/domain/**/*.rs
 rule:
-  pattern: |
-    struct $NAME {
-      $FIELD: $TYPE,
-    }
+  all:
+    - pattern: |
+        struct $NAME {
+          $FIELD: $TYPE,
+        }
+    - not:
+        inside:
+          stopBy: end
+          kind: mod_item
+          regex: "mod (test.*|benchmarks|.*_test.*)"
 constraints:
   TYPE:
     regex: "^String$|^i32$|^i64$|^f32$|^f64$|^u32$|^u64$|^bool$"

--- a/tools/ast-grep/rules/no-raw-primitive-domain-state.yml
+++ b/tools/ast-grep/rules/no-raw-primitive-domain-state.yml
@@ -13,7 +13,7 @@ rule:
           - kind: type_identifier
             regex: "^String$"
           - kind: primitive_type
-            regex: "^i32$|^i64$|^f32$|^f64$|^u32$|^u64$|^bool$"
+            regex: "^(i8|i16|i32|i64|i128|isize|u8|u16|u32|u64|u128|usize|f32|f64|bool|char)$"
     - inside:
         kind: field_declaration_list
         inside:

--- a/tools/check-merge-conflict-markers.sh
+++ b/tools/check-merge-conflict-markers.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+found=0
+while IFS= read -r -d '' file; do
+  if git show ":$file" | grep -n '<<<<<<< '; then
+    found=1
+  fi
+done < <(git diff --cached --name-only -z --diff-filter=ACMR)
+
+if [[ "$found" == "1" ]]; then
+  echo "Merge conflict markers found in staged files." >&2
+  exit 1
+fi


### PR DESCRIPTION
Closes #183

## Summary
- route Rust and security CI through shared Justfile targets
- add actionlint/zizmor security linting with documented GitHub-owned action ref policy
- add ast-grep rule tests and deterministic merge-conflict marker hook check
- migrate cargo-deny config to current schema and run advisory/license/bans/sources checks

## Validation
- just spec ISSUE=183
- cargo test --test ci_contract complete_ci_contract_includes_actions_security_linting
- just ast-grep-test
- just test-hooks
- just test-adversary ISSUE=183
- just fitness
- just ci-security
- just ci-rust
- git diff --check

## Codex Workflow Evidence
- Issue: #183
- State: `pr_ready`
- Spec: `.codex/specs/issue-183.yaml`
- Ledger: local `.codex/state/issue-183.json`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Centralized CI/CD onto shared task-runner targets; refactored workflows, permissions, and release guards
  * Broadened security tooling and policies, added dependency-pinning rules, and relaxed cargo-deny license/advisory settings
  * Added a deterministic pre-commit hook script that fails when merge conflict markers are staged without mutating content
  * Updated task-runner recipes and CI orchestration

* **Tests**
  * Added CI contract validation tests and multiple rule-driven architecture tests enforcing forbidden production patterns (unwrap/expect/panic/raw primitives)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->