### PR TITLE
perf: establish performance baseline gates

### DIFF
--- a/.codex/specs/issue-182.yaml
+++ b/.codex/specs/issue-182.yaml
@@ -1,0 +1,53 @@
+issue: 182
+goal: Establish deterministic performance baselines and regression gates for ring-buffer, proxy hot-path, and audit handoff behavior before architecture refactoring changes performance-sensitive code.
+examples:
+  - id: performance-surface-inventory
+    name: existing performance checks are inventoried against required hot paths
+    given:
+      - ring-buffer internals and proxy forwarding are documented performance islands
+      - existing benchmark and validation tests cover some performance-sensitive paths
+    when:
+      - contributors inspect the baseline documentation
+    then:
+      - the documentation identifies the CI validation tests and local benchmarks that cover ring-buffer write latency, read throughput, overflow behavior, hot-path forwarding overhead, and audit handoff cost
+      - any required scenario without reliable executable coverage is called out with the intended validation path
+  - id: ci-performance-validation
+    name: deterministic performance validation is available through the canonical command surface
+    given:
+      - CI performance gates must avoid frequent flakes
+      - the repository uses just as the canonical command surface
+    when:
+      - the CI-appropriate performance validation command runs on the current implementation
+    then:
+      - it executes deterministic validation for critical ring-buffer and proxy hot-path behavior
+      - it avoids relying on noisy wall-clock benchmark comparisons as the only correctness signal
+      - it passes on the current implementation
+  - id: local-benchmark-baseline
+    name: heavier local benchmarks have documented commands, baselines, and thresholds
+    given:
+      - deeper benchmark analysis is useful outside normal CI
+      - future architecture refactors need explicit regression thresholds
+    when:
+      - contributors inspect the benchmark documentation
+    then:
+      - local benchmark commands are documented separately from CI validation commands
+      - baseline numbers and acceptable regression thresholds are recorded for ring-buffer write latency, throughput, overflow behavior, hot-path proxy overhead, and representative audit handoff cost
+      - the thresholds explain why they are suitable for guarding later architecture work
+acceptance_criteria:
+  - Existing benchmark and performance validation tests are inventoried for ring buffer, hot path, and audit handoff coverage.
+  - A CI-appropriate performance validation command exists on the shared just command surface and is documented.
+  - A heavier local benchmark command exists on the shared just command surface or is otherwise documented with exact commands.
+  - Version-controlled documentation records baseline values and acceptable regression thresholds for ring-buffer write latency, read throughput, overflow behavior, hot-path proxy overhead, and representative audit handoff cost.
+  - The performance validation tests pass on the current implementation before architecture refactors proceed.
+non_goals:
+  - Refactoring hot-path implementation.
+  - Replacing or redesigning the ring buffer.
+  - Adding observability dashboards.
+  - Making persisted event schema or EventCore persistence changes.
+architecture_impacts:
+  - Strengthens the documented performance-island evidence required by the current architecture.
+  - Preserves the functional-core alignment initiative's performance guardrails before later refactors touch hot-path or ring-buffer code.
+test_trace_ids:
+  - performance-surface-inventory:docs/performance/baselines.md
+  - ci-performance-validation:tests/benchmark_validation.rs
+  - local-benchmark-baseline:benches/README.md

--- a/.codex/test-lists/issue-182.md
+++ b/.codex/test-lists/issue-182.md
@@ -1,0 +1,9 @@
+# Issue 182 Test List
+
+- `cargo test --test performance_baseline_contract performance_baseline_contract_documents_commands_thresholds_and_coverage`
+- `cargo test --test benchmark_validation`
+- `cargo bench --bench proxy_performance -- --quick --noplot`
+- `just bench-quick`
+- `just test-adversary ISSUE=182`
+- `just fitness`
+- `just ci-rust`

--- a/.codex/test-lists/issue-182.md
+++ b/.codex/test-lists/issue-182.md
@@ -4,6 +4,7 @@
 - `cargo test --test benchmark_validation`
 - `cargo bench --bench proxy_performance -- --quick --noplot`
 - `just bench-quick`
+- `just bench-local`
 - `just test-adversary ISSUE=182`
 - `just fitness`
 - `just ci-rust`

--- a/Justfile
+++ b/Justfile
@@ -90,6 +90,11 @@ bench-quick:
     cargo test --test benchmark_validation
     cargo bench --bench proxy_performance -- --quick --noplot
 
+bench-local:
+    cargo bench --bench proxy_performance -- --noplot
+    cargo bench --bench memory_profiling
+    cargo test --test load_testing --release -- --nocapture --test-threads=1
+
 spec ISSUE:
     issue="{{ISSUE}}"; issue="${issue#ISSUE=}"; cargo run --manifest-path tools/us-spec/Cargo.toml -- check --issue "$issue"
 

--- a/Justfile
+++ b/Justfile
@@ -93,7 +93,9 @@ bench-quick:
 bench-local:
     cargo bench --bench proxy_performance -- --noplot
     cargo bench --bench memory_profiling
-    cargo test --test load_testing --release -- --nocapture --test-threads=1
+    cargo test --test load_testing --release test_500_rps_sustained_load -- --ignored --nocapture --test-threads=1
+    cargo test --test load_testing --release test_2000_rps_burst_load -- --ignored --nocapture --test-threads=1
+    cargo test --test load_testing --release test_1000_concurrent_users -- --ignored --nocapture --test-threads=1
 
 spec ISSUE:
     issue="{{ISSUE}}"; issue="${issue#ISSUE=}"; cargo run --manifest-path tools/us-spec/Cargo.toml -- check --issue "$issue"

--- a/benches/README.md
+++ b/benches/README.md
@@ -23,11 +23,10 @@ just bench-local
 # Run memory profiling
 cargo bench --bench memory_profiling
 
-# Run load tests (requires release build for accurate results)
-cargo test --test load_testing --release -- --nocapture --test-threads=1
-
-# Run specific load test
-cargo test --test load_testing test_500_rps_sustained_load --release -- --nocapture
+# Run ignored load tests without the database-pool test
+cargo test --test load_testing --release test_500_rps_sustained_load -- --ignored --nocapture --test-threads=1
+cargo test --test load_testing --release test_2000_rps_burst_load -- --ignored --nocapture --test-threads=1
+cargo test --test load_testing --release test_1000_concurrent_users -- --ignored --nocapture --test-threads=1
 ```
 
 ## Benchmark Results Summary
@@ -91,9 +90,9 @@ Per architect guidance, Union Square must handle:
 3. Consider using dedicated load testing services (e.g., k6 Cloud, BlazeMeter)
 4. Document baseline performance metrics from representative hardware
 
-Run load tests locally with:
+Run the resource-heavy load tests locally with:
 ```bash
-cargo test --test load_testing --release -- --nocapture --test-threads=1
+just bench-local
 ```
 
 ### 🔍 Memory Profiling

--- a/benches/README.md
+++ b/benches/README.md
@@ -91,6 +91,7 @@ Per architect guidance, Union Square must handle:
 4. Document baseline performance metrics from representative hardware
 
 Run the resource-heavy load tests locally with:
+
 ```bash
 just bench-local
 ```

--- a/benches/README.md
+++ b/benches/README.md
@@ -14,6 +14,12 @@ cargo bench --bench proxy_performance
 # Quick mode for development
 cargo bench --bench proxy_performance -- --quick
 
+# CI-appropriate validation and quick benchmark run
+just bench-quick
+
+# Heavier local benchmark suite
+just bench-local
+
 # Run memory profiling
 cargo bench --bench memory_profiling
 
@@ -25,6 +31,10 @@ cargo test --test load_testing test_500_rps_sustained_load --release -- --nocapt
 ```
 
 ## Benchmark Results Summary
+
+The version-controlled baseline contract is maintained in
+`docs/performance/baselines.md`. Update that document when changing hot-path,
+ring-buffer, streaming, or audit handoff performance behavior.
 
 **✅ ALL LATENCY REQUIREMENTS MET** - Based on comprehensive benchmarks:
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -168,6 +168,9 @@ Allowed example: a ring-buffer module may use atomics, preallocated storage, and
 
 Forbidden example: a domain command must not accept `serde_json::Value`, raw request bytes, URI strings, or header tuples because parsing those values is adapter work, not domain work.
 
+Detailed performance-island guardrails, regression-threshold rationale, and
+documented exception constraints live in `docs/guardrails/performance-islands.md`.
+
 ## Data Flow
 
 ```text

--- a/docs/codex-command-surface.md
+++ b/docs/codex-command-surface.md
@@ -17,6 +17,7 @@ Core checks:
 - `just build`
 - `just build-release`
 - `just bench-quick`
+- `just bench-local`
 
 Harness checks:
 

--- a/docs/guardrails/performance-islands.md
+++ b/docs/guardrails/performance-islands.md
@@ -29,6 +29,19 @@ Constraints:
 - The public API (`write`, `read`, `stats`, `overflow_count`) is narrow: `write` accepts a semantic `RequestId` and borrows payload bytes (`&[u8]`) which it copies into pre-allocated slot storage; `read` returns `Option<(RequestId, Vec<u8>)>`; counters are primitive types.
 - Clock calls (e.g., `chrono::Utc::now()`) MUST be captured outside `unsafe` blocks to avoid hidden side effects inside the performance-critical path.
 
+## Regression Threshold Rationale
+
+CI validation thresholds are intentionally broad. They catch severe regressions
+and accidental blocking work while avoiding flakes from shared CI hardware. Local
+benchmark thresholds are tighter relative checks because Criterion results are
+more useful when compared on the same hardware and under similar load.
+
+The 5ms proxy budget is the user-visible latency guard. The ring-buffer write
+path remains a documented performance island and should stay comfortably
+sub-microsecond in local benchmarks. Any future refactor that routes hot-path or
+ring-buffer behavior through new abstractions must update the relevant baseline
+evidence before it is accepted.
+
 ## Requirements
 
 Performance islands MUST:

--- a/docs/guardrails/performance-islands.md
+++ b/docs/guardrails/performance-islands.md
@@ -36,11 +36,13 @@ and accidental blocking work while avoiding flakes from shared CI hardware. Loca
 benchmark thresholds are tighter relative checks because Criterion results are
 more useful when compared on the same hardware and under similar load.
 
-The 5ms proxy budget is the user-visible latency guard. The ring-buffer write
-path remains a documented performance island and should stay comfortably
-sub-microsecond in local benchmarks. Any future refactor that routes hot-path or
-ring-buffer behavior through new abstractions must update the relevant baseline
-evidence before it is accepted.
+The 5ms proxy budget refers to the maximum critical-path latency enforced by CI
+deterministic validation (`benchmark_validation`: average <1ms, max <5ms) and
+serves as the user-visible latency guard. The ring-buffer write path remains a
+documented performance island and should stay comfortably sub-microsecond in
+local benchmarks. Any future refactor that routes hot-path or ring-buffer
+behavior through new abstractions must update the relevant baseline evidence
+before it is accepted.
 
 ## Requirements
 

--- a/docs/performance/baselines.md
+++ b/docs/performance/baselines.md
@@ -50,16 +50,6 @@ audit handoff behavior.
 | Hot-path proxy overhead | `tests/benchmark_validation.rs::test_critical_path_performance` | `benches/proxy_performance.rs::hot_path_simulation` and `complete_proxy_flow_simulation` | 717.68ns median for complete hot-path simulation, 740.03ns for hot-path latency distribution, and 1.7269us for simulated complete proxy request in the `just bench-quick` run for issue #182 | CI must stay below the 5ms hot-path budget; local Criterion median should not regress by more than 2x without documented architecture approval |
 | Representative audit handoff cost | `tests/benchmark_validation.rs::test_allocation_performance` | `benches/proxy_performance.rs::audit_event_serialization` and `memory_allocation` | request serialization 541.90ns median, response serialization 501.95ns median, and audit event allocation 1.0235us median in the `just bench-quick` run for issue #182 | Per-event deterministic validation must stay below 1ms; local Criterion median should not regress by more than 2x without documenting the added semantic work |
 
-## Threshold Rationale
-
-The CI validation thresholds are intentionally broad. They catch severe
-regressions and accidental blocking work while avoiding flakes from shared CI
-hardware. The local benchmark thresholds are tighter relative checks because
-Criterion results are more useful when compared on the same hardware and under
-similar load.
-
-The 5ms proxy budget is the user-visible latency guard. The ring-buffer write
-path remains a documented performance island and should stay comfortably
-sub-microsecond in local benchmarks. Any future refactor that routes hot-path or
-ring-buffer behavior through new abstractions must update this document with
-fresh baseline evidence before it is accepted.
+Threshold rationale and architectural rules for accepting performance-island
+changes live in `docs/guardrails/performance-islands.md`. This file records the
+issue #182 baseline evidence and command surface.

--- a/docs/performance/baselines.md
+++ b/docs/performance/baselines.md
@@ -1,0 +1,65 @@
+# Performance Baselines
+
+Issue: #182
+
+This document records the baseline gates that protect Union Square's documented
+performance islands before architecture refactoring touches ring-buffer, proxy
+hot-path, streaming, or audit handoff code.
+
+## Commands
+
+### CI validation
+
+Run:
+
+```bash
+just bench-quick
+```
+
+`just bench-quick` is the CI-appropriate performance command. It runs
+`cargo test --test benchmark_validation` for deterministic validation and
+`cargo bench --bench proxy_performance -- --quick --noplot` for fast Criterion
+coverage of CPU-bound benchmark scenarios.
+
+This command is allowed in CI because it avoids network IO, database IO, and
+external providers. The deterministic test portion is the regression gate; the
+quick Criterion run adds trend evidence without being the only correctness
+signal.
+
+### Local benchmark
+
+Run:
+
+```bash
+just bench-local
+```
+
+`just bench-local` is the heavier local benchmark suite. It runs the full
+`proxy_performance` Criterion benchmark, the `memory_profiling` benchmark, and
+release-mode load tests. Use it on a quiet workstation or representative
+performance host when validating changes to hot-path, ring-buffer, streaming, or
+audit handoff behavior.
+
+## Coverage Inventory
+
+| Scenario | CI validation | Local benchmark | Baseline | Regression threshold |
+| --- | --- | --- | --- | --- |
+| Ring-buffer write latency | `tests/benchmark_validation.rs::test_critical_path_performance` and `src/proxy/ring_buffer_performance_test.rs::test_single_threaded_performance` | `benches/proxy_performance.rs::ring_buffer_performance/write_*kb` | 11.888ns median for 1KB writes, 11.975ns for 10KB writes, and 11.590ns for 64KB writes in the `just bench-quick` run for issue #182; deterministic test requires average below 1ms and max below 5ms for 1KB writes | CI must remain below the deterministic 1ms average and 5ms max budgets; local Criterion median should not regress by more than 2x without documented hardware or workload justification |
+| Ring-buffer read throughput | ring-buffer correctness and concurrent tests exercise readable handoff without loss under capacity | `benches/memory_profiling.rs::profile_ring_buffer` plus full proxy benchmark readback-adjacent scenarios | read path remains single-consumer and bounded by preallocated slot size; no existing standalone read-throughput Criterion case | Add a dedicated read-throughput benchmark before changing read internals; until then, no read-path change may ship without `just bench-local` evidence and updated baseline numbers |
+| Ring-buffer overflow behavior | `src/proxy/ring_buffer_tests.rs` property and stress coverage validates under-capacity, oversized payload, wraparound, and stats behavior | release-mode load tests exercise sustained pressure | overflow is explicit via `DroppedEventCount` and fail-when-busy semantics | Overflow counters must remain monotonic and no successful write may corrupt readable payloads; any changed overflow policy requires a new deterministic validation test |
+| Hot-path proxy overhead | `tests/benchmark_validation.rs::test_critical_path_performance` | `benches/proxy_performance.rs::hot_path_simulation` and `complete_proxy_flow_simulation` | 717.68ns median for complete hot-path simulation, 740.03ns for hot-path latency distribution, and 1.7269us for simulated complete proxy request in the `just bench-quick` run for issue #182 | CI must stay below the 5ms hot-path budget; local Criterion median should not regress by more than 2x without documented architecture approval |
+| Representative audit handoff cost | `tests/benchmark_validation.rs::test_allocation_performance` | `benches/proxy_performance.rs::audit_event_serialization` and `memory_allocation` | request serialization 541.90ns median, response serialization 501.95ns median, and audit event allocation 1.0235us median in the `just bench-quick` run for issue #182 | Per-event deterministic validation must stay below 1ms; local Criterion median should not regress by more than 2x without documenting the added semantic work |
+
+## Threshold Rationale
+
+The CI validation thresholds are intentionally broad. They catch severe
+regressions and accidental blocking work while avoiding flakes from shared CI
+hardware. The local benchmark thresholds are tighter relative checks because
+Criterion results are more useful when compared on the same hardware and under
+similar load.
+
+The 5ms proxy budget is the user-visible latency guard. The ring-buffer write
+path remains a documented performance island and should stay comfortably
+sub-microsecond in local benchmarks. Any future refactor that routes hot-path or
+ring-buffer behavior through new abstractions must update this document with
+fresh baseline evidence before it is accepted.

--- a/tests/performance_baseline_contract.rs
+++ b/tests/performance_baseline_contract.rs
@@ -19,13 +19,15 @@ fn performance_baseline_contract_documents_commands_thresholds_and_coverage() ->
     assert!(
         bench_local.contains("cargo bench --bench proxy_performance -- --noplot")
             && bench_local.contains("cargo bench --bench memory_profiling")
-            && bench_local.contains("cargo test --test load_testing --release")
-            && bench_local.contains("test_500_rps_sustained_load")
-            && bench_local.contains("test_2000_rps_burst_load")
-            && bench_local.contains("test_1000_concurrent_users")
-            && bench_local.contains("--ignored")
-            && bench_local.contains("--nocapture")
-            && bench_local.contains("--test-threads=1"),
+            && bench_local.contains(
+                "cargo test --test load_testing --release test_500_rps_sustained_load -- --ignored --nocapture --test-threads=1",
+            )
+            && bench_local.contains(
+                "cargo test --test load_testing --release test_2000_rps_burst_load -- --ignored --nocapture --test-threads=1",
+            )
+            && bench_local.contains(
+                "cargo test --test load_testing --release test_1000_concurrent_users -- --ignored --nocapture --test-threads=1",
+            ),
         "bench-local should run full proxy benchmark, memory profiling, and ignored release-mode load tests"
     );
 

--- a/tests/performance_baseline_contract.rs
+++ b/tests/performance_baseline_contract.rs
@@ -17,9 +17,16 @@ fn performance_baseline_contract_documents_commands_thresholds_and_coverage() ->
 
     let bench_local = just_target_body(&justfile, "bench-local")?;
     assert!(
-        bench_local.contains("cargo bench --bench proxy_performance")
-            && bench_local.contains("cargo bench --bench memory_profiling"),
-        "bench-local should expose the heavier local benchmark suite"
+        bench_local.contains("cargo bench --bench proxy_performance -- --noplot")
+            && bench_local.contains("cargo bench --bench memory_profiling")
+            && bench_local.contains("cargo test --test load_testing --release")
+            && bench_local.contains("test_500_rps_sustained_load")
+            && bench_local.contains("test_2000_rps_burst_load")
+            && bench_local.contains("test_1000_concurrent_users")
+            && bench_local.contains("--ignored")
+            && bench_local.contains("--nocapture")
+            && bench_local.contains("--test-threads=1"),
+        "bench-local should run full proxy benchmark, memory profiling, and ignored release-mode load tests"
     );
 
     for required in [

--- a/tests/performance_baseline_contract.rs
+++ b/tests/performance_baseline_contract.rs
@@ -1,0 +1,85 @@
+use std::fs;
+
+#[test]
+fn performance_baseline_contract_documents_commands_thresholds_and_coverage() -> Result<(), String>
+{
+    let justfile = fs::read_to_string("Justfile")
+        .map_err(|error| format!("Justfile should be readable: {error}"))?;
+    let baselines = fs::read_to_string("docs/performance/baselines.md")
+        .map_err(|error| format!("performance baselines should be documented: {error}"))?;
+
+    let bench_quick = just_target_body(&justfile, "bench-quick")?;
+    assert!(
+        bench_quick.contains("cargo test --test benchmark_validation")
+            && bench_quick.contains("cargo bench --bench proxy_performance -- --quick --noplot"),
+        "bench-quick should run deterministic validation plus quick Criterion checks"
+    );
+
+    let bench_local = just_target_body(&justfile, "bench-local")?;
+    assert!(
+        bench_local.contains("cargo bench --bench proxy_performance")
+            && bench_local.contains("cargo bench --bench memory_profiling"),
+        "bench-local should expose the heavier local benchmark suite"
+    );
+
+    for required in [
+        "just bench-quick",
+        "just bench-local",
+        "Ring-buffer write latency",
+        "Ring-buffer read throughput",
+        "Ring-buffer overflow behavior",
+        "Hot-path proxy overhead",
+        "Representative audit handoff cost",
+        "CI validation",
+        "Local benchmark",
+        "Regression threshold",
+    ] {
+        assert!(
+            baselines.contains(required),
+            "performance baseline documentation should mention {required}"
+        );
+    }
+
+    Ok(())
+}
+
+fn just_target_body<'a>(justfile: &'a str, target: &str) -> Result<&'a str, String> {
+    let prefix = format!("{target}:");
+    block_from_line(
+        justfile,
+        |line| line.starts_with(&prefix),
+        is_just_target_header,
+        || format!("Justfile should define {target}"),
+    )
+}
+
+fn block_from_line(
+    text: &str,
+    is_start: impl Fn(&str) -> bool,
+    is_next_block: impl Fn(&str) -> bool,
+    missing_message: impl FnOnce() -> String,
+) -> Result<&str, String> {
+    let mut start = None;
+    let mut offset = 0;
+
+    for line in text.split_inclusive('\n') {
+        let trimmed_newline = line.trim_end_matches(['\r', '\n']);
+        if let Some(start_offset) = start {
+            if offset != start_offset && is_next_block(trimmed_newline) {
+                return Ok(&text[start_offset..offset]);
+            }
+        } else if is_start(trimmed_newline) {
+            start = Some(offset);
+        }
+
+        offset += line.len();
+    }
+
+    start
+        .map(|start_offset| &text[start_offset..])
+        .ok_or_else(missing_message)
+}
+
+fn is_just_target_header(line: &str) -> bool {
+    !line.is_empty() && !line.starts_with(' ') && !line.starts_with('\t') && line.contains(':')
+}


### PR DESCRIPTION
## Summary

- add a behavior spec and TDD test list for issue #182
- add a contract test requiring performance baseline documentation and benchmark command coverage
- document CI and local performance validation commands, baseline values, coverage inventory, and regression thresholds
- expose `just bench-local` alongside existing `just bench-quick`

## Validation

- `cargo test --test performance_baseline_contract performance_baseline_contract_documents_commands_thresholds_and_coverage`
- `cargo test --test benchmark_validation`
- `just bench-quick`
- `just test-adversary ISSUE=182`
- `just fitness`
- `just ci-rust`
- `git diff --check`

## Codex Workflow Evidence

- Issue: #182
- State: `pr_ready`
- Spec: `.codex/specs/issue-182.yaml`
- Ledger: local `.codex/state/issue-182.json`

## Notes

Review-agent delegation failed during the expert-review step by returning nested task metadata instead of findings. I logged that separately as #231 and completed a manual focused architecture/test review for this PR.

Closes #182

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a version-controlled performance baseline spec with recorded baseline numbers, CI regression thresholds, coverage mappings, and guidance for deterministic CI vs. heavier local benchmarks.
  * Documented new benchmark entry points and updated benchmark/readme guidance and architecture guardrails.

* **Tests**
  * Added a contract test that verifies presence of the documented benchmarking/validation commands, coverage inventory, and required baseline sections.

* **Chores**
  * Added a local benchmarking command group to the documented command surface and an accompanying test-list checklist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->