### PR TITLE
docs: document squash-merge cleanup workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,14 @@ Red-green-refactor means:
 
 PRs must be focused on one concern. Do not mix unrelated refactors with behavior changes. Use CodeRabbit feedback as part of the normal loop: deterministic local gates catch enforceable issues; CodeRabbit can catch qualitative review issues that are cheaper to fix after review.
 
+## Local Cleanup
+
+PRs are squash-merged into `main`. After a PR is merged, `git branch -d` may
+refuse to delete the local PR branch because the original branch commits are not
+ancestors of `main`. Before using `git branch -D` for cleanup, verify the branch
+content is already represented on current `main`, for example with
+`git diff main..branch-name` and relevant PR metadata.
+
 ## RTK Token Savings
 
 Use `rtk` for high-output, read-heavy shell commands such as `git diff`, `git log`, `rg`, `find`, `cargo test`, `cargo check`, and `docker compose logs`. If the pre-tool hook rejects a raw read-heavy command with an RTK rewrite suggestion, rerun the suggested `rtk ...` command.


### PR DESCRIPTION
## Summary

- Document that Union Square PRs are squash-merged into main.
- Explain why git branch -d can reject local PR branch cleanup after squash merge.
- Require content and PR metadata verification before using git branch -D during cleanup.

Closes #234

## Validation

- git diff --check
- just fmt-check
- just ci-harness

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on safely managing local branches after pull request merges, including verification procedures and recommended command-line approaches for branch cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->