### PR TITLE
fix(harness): block draft PRs after readiness

### DIFF
--- a/.codex/hooks/pre-tool-use.sh
+++ b/.codex/hooks/pre-tool-use.sh
@@ -125,6 +125,11 @@ if [[ "$policy_command" =~ gh[[:space:]]+pr[[:space:]]+create|gh[[:space:]]+pr[[
     exit 1
   fi
   require_valid_spec_for_active_issue "PR actions"
+  if [[ "$policy_command" =~ gh[[:space:]]+pr[[:space:]]+create ]] \
+    && [[ "$policy_command" =~ (^|[[:space:]])--draft($|[[:space:]]) ]]; then
+    echo "Draft PR creation is blocked after pr_ready. Open a ready-for-review PR by default, or surface the blocker before publishing." >&2
+    exit 1
+  fi
 fi
 
 if [[ "$policy_command" =~ git[[:space:]]+commit ]]; then

--- a/.codex/hooks/test-hooks.sh
+++ b/.codex/hooks/test-hooks.sh
@@ -86,17 +86,22 @@ done
 
 printf '%s' '{"tool_input":{"command":"gh pr create --fill"}}' | .codex/hooks/pre-tool-use.sh >/dev/null
 
-draft_pr_output="$(
-  printf '%s' '{"tool_input":{"command":"gh pr create --draft --fill"}}' \
-    | .codex/hooks/pre-tool-use.sh 2>&1
-)" && {
-  echo "expected PR hook to reject draft PR creation after pr_ready" >&2
-  exit 1
-}
-if ! grep -qi "ready-for-review" <<<"$draft_pr_output"; then
-  echo "expected draft PR rejection to explain ready-for-review default" >&2
-  exit 1
-fi
+for draft_pr_command in \
+  "gh pr create --draft --fill" \
+  "gh pr create --fill --draft"
+do
+  draft_pr_output="$(
+    printf '{"tool_input":{"command":"%s"}}' "$draft_pr_command" \
+      | .codex/hooks/pre-tool-use.sh 2>&1
+  )" && {
+    echo "expected PR hook to reject draft PR creation after pr_ready: $draft_pr_command" >&2
+    exit 1
+  }
+  if ! grep -qi "ready-for-review" <<<"$draft_pr_output"; then
+    echo "expected draft PR rejection to explain ready-for-review default: $draft_pr_command" >&2
+    exit 1
+  fi
+done
 
 conflict_repo="$backup_dir/conflict-repo"
 mkdir "$conflict_repo"

--- a/.codex/hooks/test-hooks.sh
+++ b/.codex/hooks/test-hooks.sh
@@ -86,6 +86,18 @@ done
 
 printf '%s' '{"tool_input":{"command":"gh pr create --fill"}}' | .codex/hooks/pre-tool-use.sh >/dev/null
 
+draft_pr_output="$(
+  printf '%s' '{"tool_input":{"command":"gh pr create --draft --fill"}}' \
+    | .codex/hooks/pre-tool-use.sh 2>&1
+)" && {
+  echo "expected PR hook to reject draft PR creation after pr_ready" >&2
+  exit 1
+}
+if ! grep -qi "ready-for-review" <<<"$draft_pr_output"; then
+  echo "expected draft PR rejection to explain ready-for-review default" >&2
+  exit 1
+fi
+
 conflict_repo="$backup_dir/conflict-repo"
 mkdir "$conflict_repo"
 git -C "$conflict_repo" init -q

--- a/.codex/hooks/test-hooks.sh
+++ b/.codex/hooks/test-hooks.sh
@@ -87,6 +87,7 @@ done
 printf '%s' '{"tool_input":{"command":"gh pr create --fill"}}' | .codex/hooks/pre-tool-use.sh >/dev/null
 
 for draft_pr_command in \
+  "gh pr create --draft" \
   "gh pr create --draft --fill" \
   "gh pr create --fill --draft"
 do

--- a/.codex/rules/default.rules
+++ b/.codex/rules/default.rules
@@ -280,7 +280,20 @@ prefix_rule(
     ],
     not_match = [
         "gh pr view 210",
+        "gh pr create --fill",
+    ],
+)
+
+prefix_rule(
+    pattern = ["gh", "pr", "create", "--draft"],
+    decision = "forbidden",
+    justification = "After the issue ledger reaches pr_ready, publish a ready-for-review PR by default. Surface a blocker instead of opening a draft.",
+    match = [
         "gh pr create --draft",
+        "gh pr create --draft --fill",
+    ],
+    not_match = [
+        "gh pr create --fill",
     ],
 )
 
@@ -397,10 +410,10 @@ prefix_rule(
 prefix_rule(
     pattern = ["gh", "pr", ["view", "list", "status", "create", "edit", "comment", "ready", "diff", "checkout"]],
     decision = "allow",
-    justification = "PR inspection and draft/update operations are needed for autonomous delivery; merging remains forbidden.",
+    justification = "PR inspection and ready-for-review create/update operations are needed for autonomous delivery; merging remains forbidden.",
     match = [
         "gh pr view 210",
-        "gh pr create --draft --fill",
+        "gh pr create --fill",
         "gh pr edit 210 --body-file /tmp/body.md",
         "gh pr checkout 210",
     ],

--- a/.codex/rules/default.rules
+++ b/.codex/rules/default.rules
@@ -285,19 +285,6 @@ prefix_rule(
 )
 
 prefix_rule(
-    pattern = ["gh", "pr", "create", "--draft"],
-    decision = "forbidden",
-    justification = "After the issue ledger reaches pr_ready, publish a ready-for-review PR by default. Surface a blocker instead of opening a draft.",
-    match = [
-        "gh pr create --draft",
-        "gh pr create --draft --fill",
-    ],
-    not_match = [
-        "gh pr create --fill",
-    ],
-)
-
-prefix_rule(
     pattern = ["rm", "-rf", "/"],
     decision = "forbidden",
     justification = "Refuse broad filesystem deletion.",
@@ -421,6 +408,9 @@ prefix_rule(
         "gh pr merge 210",
     ],
 )
+
+# Draft PR creation is enforced in `.codex/hooks/pre-tool-use.sh`, where the
+# `--draft` flag can be detected in any argument order after `gh pr create`.
 
 prefix_rule(
     pattern = ["just"],

--- a/.codex/specs/issue-233.yaml
+++ b/.codex/specs/issue-233.yaml
@@ -1,0 +1,35 @@
+issue: 233
+goal: PR publishing defaults to ready-for-review pull requests after the agent workflow reaches PR readiness.
+examples:
+  - id: rejects-draft-pr-after-pr-ready
+    name: draft PR creation is rejected after workflow PR readiness
+    given:
+      - an active issue ledger has reached pr_ready
+      - the behavior spec for that issue is valid
+    when:
+      - the agent attempts to create a draft pull request
+    then:
+      - the pre-tool hook rejects the command
+      - the rejection explains that PRs should be ready for review by default
+  - id: allows-ready-pr-after-pr-ready
+    name: ready PR creation is allowed after workflow PR readiness
+    given:
+      - an active issue ledger has reached pr_ready
+      - the behavior spec for that issue is valid
+    when:
+      - the agent attempts to create a pull request without draft flags
+    then:
+      - the pre-tool hook allows the command
+acceptance_criteria:
+  - Agent-facing PR publishing instructions say not to use draft PRs by default.
+  - Repo-local PR creation command, checklist, or skill guidance prefers ready-for-review PRs.
+  - A deterministic guard flags draft PR creation when the active issue ledger is already pr_ready.
+  - Workflow docs explain when a draft PR is acceptable.
+non_goals:
+  - Changing GitHub merge permissions.
+  - Blocking explicit draft PRs before the workflow reaches pr_ready.
+architecture_impacts:
+  - none
+test_trace_ids:
+  - rejects-draft-pr-after-pr-ready:.codex/hooks/test-hooks.sh
+  - allows-ready-pr-after-pr-ready:.codex/hooks/test-hooks.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ This file is the primary Codex instruction file for Union Square.
 15. Run relevant expert review agents and record it with `just agent record-review <number>`.
 16. Run `just ci-rust`, then `just agent ready-to-commit <number>`.
 17. Commit with Conventional Commits. Do not bypass hooks.
-18. Push the branch, open or update the PR after `just agent ready-to-pr <number>`, and address CodeRabbit feedback normally.
+18. Push the branch, open or update a ready-for-review PR after `just agent ready-to-pr <number>`, and address CodeRabbit feedback normally.
 
 ## Architecture Source Of Truth
 
@@ -77,6 +77,11 @@ Red-green-refactor means:
 ## PR Hygiene
 
 PRs must be focused on one concern. Do not mix unrelated refactors with behavior changes. Use CodeRabbit feedback as part of the normal loop: deterministic local gates catch enforceable issues; CodeRabbit can catch qualitative review issues that are cheaper to fix after review.
+
+After `just agent ready-to-pr <number>`, open normal ready-for-review PRs by
+default. Use a draft PR only when the user explicitly asks for a draft or when a
+documented blocker prevents review readiness; in that case, surface the blocker
+before publishing.
 
 ## Local Cleanup
 

--- a/docs/codex-command-surface.md
+++ b/docs/codex-command-surface.md
@@ -47,6 +47,10 @@ Workflow commands:
 - `just agent ready-to-commit <number>`
 - `just agent ready-to-pr <number>`
 
+After `ready-to-pr`, publish normal ready-for-review PRs by default. Draft PRs
+are reserved for explicit user requests or documented blockers that prevent
+review readiness.
+
 Local services:
 
 - `just db-up`

--- a/docs/guardrails/pr-scope-hygiene.md
+++ b/docs/guardrails/pr-scope-hygiene.md
@@ -18,7 +18,7 @@ Pull requests must be focused, atomic, and contain only changes related to a sin
 If a change is naturally large (e.g., introducing a new major feature):
 - Break it into stacked PRs
 - Each PR should be reviewable independently
-- Use draft PRs for intermediate steps
+- Use draft PRs only when the user explicitly requests a draft or a documented blocker prevents review readiness. Once the issue ledger reaches `pr_ready`, publish ready-for-review PRs by default.
 
 ## Commit Messages Within PRs
 


### PR DESCRIPTION
Closes #233

## Summary
- block `gh pr create --draft` after the active issue ledger reaches `pr_ready`
- keep ready-for-review PR creation allowed after `pr_ready`
- update agent-facing docs and rules to prefer ready PRs by default

## Validation
- `.codex/hooks/test-hooks.sh`
- `just spec ISSUE=233`
- `just test-adversary ISSUE=233`
- `just fitness`
- `just ci-harness`
- `just ci-rust`

## Codex Workflow Evidence
- Issue: #233
- State: `pr_ready`
- Spec: `.codex/specs/issue-233.yaml`
- Ledger: local `.codex/state/issue-233.json`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Draft pull requests are now blocked once an item reaches the "pr_ready" workflow state; ready-for-review PRs are created by default.

* **Documentation**
  * Clarified guidance across docs that ready-for-review is the default PR type after ready-to-pr; drafts are reserved for explicit requests or documented blockers.

* **Tests**
  * Added/updated tests to verify draft PR blocking and default ready-for-review behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->