### PR TITLE
chore: update post-transfer workflow references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,20 +245,6 @@ jobs:
       env:
         DATABASE_URL: postgres://postgres:postgres@localhost:5432/union_square
 
-    - name: Load Codecov token
-      id: load_secrets
-      uses: 1password/load-secrets-action@v4
-      env:
-        OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-        CODECOV_TOKEN: op://Github Secrets/CODECOV_TOKEN/credential
-
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2
-      with:
-        file: lcov.info
-        token: ${{ steps.load_secrets.outputs.CODECOV_TOKEN }}
-        fail_ci_if_error: false
-
   build:
     name: Build
     needs: changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,11 +245,18 @@ jobs:
       env:
         DATABASE_URL: postgres://postgres:postgres@localhost:5432/union_square
 
+    - name: Load Codecov token
+      id: load_secrets
+      uses: 1password/load-secrets-action@v4
+      env:
+        OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+        CODECOV_TOKEN: op://Github Secrets/CODECOV_TOKEN/credential
+
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2
       with:
         file: lcov.info
-        token: ${{ secrets.CODECOV_TOKEN }}
+        token: ${{ steps.load_secrets.outputs.CODECOV_TOKEN }}
         fail_ci_if_error: false
 
   build:

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -12,9 +12,8 @@ on:
 jobs:
   release-plz:
     name: Release-plz
-    uses: slipstream-eng/gha-workflows/.github/workflows/rust-release-plz.yml@main
+    uses: jwilger/gha-workflows/.github/workflows/rust-release-plz.yml@main
     with:
       runs-on: self-hosted-gregor
     secrets:
-      cargo-registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-      release-signing-key: ${{ secrets.RELEASE_SIGNING_KEY }}
+      op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   release-plz:
     name: Release-plz
-    uses: jwilger/gha-workflows/.github/workflows/rust-release-plz.yml@main
+    uses: jwilger/gha-workflows/.github/workflows/rust-release-plz.yml@4f29cb994188c20786a9fda85ebabd113c910d89
     with:
       runs-on: ubuntu-latest
     secrets:

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -14,6 +14,6 @@ jobs:
     name: Release-plz
     uses: jwilger/gha-workflows/.github/workflows/rust-release-plz.yml@main
     with:
-      runs-on: self-hosted-gregor
+      runs-on: ubuntu-latest
     secrets:
       op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,9 +75,9 @@ checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arraydeque"


### PR DESCRIPTION
Updates post-transfer repository references and moves workflow runtime secret access
to the shared 1Password `Github Secrets` vault.

This only changes repositories that were part of the `slipstream-eng` migration
inventory.

Secret-loading changes:

- keep `OP_SERVICE_ACCOUNT_TOKEN` as the only GitHub Actions bootstrap secret
- load runtime values with `1password/load-secrets-action@v4`
- use `op://Github Secrets/...` references for cargo/Hex publish tokens,
  the GitHub release automation PAT, and the release signing SSH key
- remove Codecov and OpenAI/Anthropic/Claude token usage from CI
- use npm trusted publishing/OIDC instead of `NPM_TOKEN`
- keep built-in `GITHUB_TOKEN` usage unchanged

Runner migration:

- replace `self-hosted-gregor` with `ubuntu-latest` where the transferred
  personal-account repos no longer have an eligible shared runner
- add the repo-standard Determinate Systems Nix installer/cache actions before
  `nix develop` steps where needed

Verification run where applicable:

- `git diff --check`
- YAML parse check with Python `yaml.safe_load`
- `actionlint`

Notes:

- Historical generated changelog links were left alone.
- Forgejo product/runtime references were left alone unless they pointed at
  migrated source repositories.
- The remaining 1Password runtime secrets are populated: Cargo, Hex, GitHub
  release automation PAT, and release signing key.
- `GH_RELEASE_AUTOMATION_TOKEN` is a fine-grained PAT. Required repository
  permissions: Contents read/write, Pull requests read/write, Issues read/write
  for release-please repos, Metadata read-only. Do not grant Actions/Workflows
  unless release automation must edit workflow files; do not grant
  Administration unless protected tag rules block release tag creation.
- npm packages must be configured in npm as trusted publishers for their
  GitHub repository and publish workflow before tokenless npm publishing works.
