### PR TITLE
ci: submit pull requests to Trunk merge queue

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   release-plz:
     name: Release-plz
-    uses: slipstream-eng/gha-workflows/.github/workflows/rust-release-plz.yml@main
+    uses: jwilger/gha-workflows/.github/workflows/rust-release-plz.yml@4f29cb994188c20786a9fda85ebabd113c910d89
     with:
       runs-on: self-hosted-gregor
     secrets:

--- a/.github/workflows/trunk-submit.yml
+++ b/.github/workflows/trunk-submit.yml
@@ -24,6 +24,9 @@ permissions:
 jobs:
   submit:
     name: Submit PR to Trunk
+    concurrency:
+      group: trunk-submit-${{ github.repository }}-${{ github.event.pull_request.number || inputs.pr_number }}
+      cancel-in-progress: false
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (

--- a/.github/workflows/trunk-submit.yml
+++ b/.github/workflows/trunk-submit.yml
@@ -1,0 +1,148 @@
+name: Trunk Merge Queue
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number to submit to Trunk
+        required: true
+        type: number
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+      - synchronize
+  pull_request_review:
+    types:
+      - submitted
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  submit:
+    name: Submit PR to Trunk
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event_name == 'pull_request_target' &&
+        github.event.pull_request.draft == false &&
+        github.event.pull_request.base.ref == github.event.repository.default_branch &&
+        github.event.pull_request.head.repo.owner.login == github.repository_owner
+      ) ||
+      (
+        github.event_name == 'pull_request_review' &&
+        github.event.review.state == 'approved' &&
+        github.event.pull_request.draft == false &&
+        github.event.pull_request.base.ref == github.event.repository.default_branch &&
+        github.event.pull_request.head.repo.owner.login == github.repository_owner
+      )
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Load Trunk token
+        id: load_secrets
+        uses: 1password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556 # v4
+        with:
+          version: 2.34.1
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          TRUNK_API_TOKEN: op://Github Secrets/TRUNK_API_TOKEN/credential
+
+      - name: Submit pull request
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TRUNK_API_TOKEN: ${{ steps.load_secrets.outputs.TRUNK_API_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_PR_NUMBER: ${{ inputs.pr_number }}
+          EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
+          REPOSITORY_NAME: ${{ github.event.repository.name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          pr_number="${DISPATCH_PR_NUMBER:-${EVENT_PR_NUMBER:-}}"
+          if [ -z "$pr_number" ]; then
+            echo "No pull request number was available for this event." >&2
+            exit 1
+          fi
+          if [ -z "${TRUNK_API_TOKEN:-}" ]; then
+            echo "TRUNK_API_TOKEN was not loaded from 1Password." >&2
+            exit 1
+          fi
+
+          pr_json="$(gh pr view "$pr_number" -R "$REPOSITORY_OWNER/$REPOSITORY_NAME" --json number,state,isDraft,baseRefName,headRepositoryOwner,url)"
+          state="$(jq -r '.state' <<<"$pr_json")"
+          is_draft="$(jq -r '.isDraft' <<<"$pr_json")"
+          base_ref="$(jq -r '.baseRefName' <<<"$pr_json")"
+          head_owner="$(jq -r '.headRepositoryOwner.login' <<<"$pr_json")"
+          pr_url="$(jq -r '.url' <<<"$pr_json")"
+          default_branch="$(gh api "repos/$REPOSITORY_OWNER/$REPOSITORY_NAME" --jq '.default_branch')"
+
+          if [ "$state" != "OPEN" ]; then
+            echo "Skipping $pr_url because it is $state."
+            exit 0
+          fi
+          if [ "$is_draft" = "true" ]; then
+            echo "Skipping $pr_url because it is a draft."
+            exit 0
+          fi
+          if [ "$base_ref" != "$default_branch" ]; then
+            echo "Skipping $pr_url because its base branch ($base_ref) is not the default branch."
+            exit 0
+          fi
+          if [ "$EVENT_NAME" != "workflow_dispatch" ] && [ "$head_owner" != "$REPOSITORY_OWNER" ]; then
+            echo "Skipping $pr_url because automatic submission is limited to same-owner branches."
+            exit 0
+          fi
+
+          payload="$(
+            jq -nc \
+              --arg owner "$REPOSITORY_OWNER" \
+              --arg name "$REPOSITORY_NAME" \
+              --arg targetBranch "$base_ref" \
+              --argjson prNumber "$pr_number" \
+              '{
+                repo: {
+                  host: "github.com",
+                  owner: $owner,
+                  name: $name
+                },
+                targetBranch: $targetBranch,
+                pr: {
+                  number: $prNumber
+                }
+              }'
+          )"
+
+          response_file="$(mktemp)"
+          status="$(
+            curl --silent --show-error \
+              --max-time 30 \
+              --connect-timeout 10 \
+              --output "$response_file" \
+              --write-out "%{http_code}" \
+              --request POST \
+              --url https://api.trunk.io/v1/submitPullRequest \
+              --header "Content-Type: application/json" \
+              --header "x-api-token: $TRUNK_API_TOKEN" \
+              --data "$payload"
+          )"
+
+          if [[ "$status" =~ ^2[0-9][0-9]$ ]]; then
+            echo "Submitted $pr_url to the Trunk merge queue."
+            cat "$response_file"
+            exit 0
+          fi
+
+          if [[ "$status" == "409" ]]; then
+            echo "$pr_url was already submitted to the Trunk merge queue."
+            cat "$response_file"
+            exit 0
+          fi
+
+          echo "Trunk submit failed with HTTP $status." >&2
+          cat "$response_file" >&2
+          exit 1

--- a/.github/workflows/trunk-submit.yml
+++ b/.github/workflows/trunk-submit.yml
@@ -44,11 +44,18 @@ jobs:
       )
     runs-on: ubuntu-24.04
     steps:
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+
       - name: Load Trunk token
         id: load_secrets
         uses: 1password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556 # v4
         with:
           version: 2.34.1
+          export-env: false
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           TRUNK_API_TOKEN: op://Github Secrets/TRUNK_API_TOKEN/credential
@@ -63,89 +70,4 @@ jobs:
           REPOSITORY_OWNER: ${{ github.repository_owner }}
           REPOSITORY_NAME: ${{ github.event.repository.name }}
         shell: bash
-        run: |
-          set -euo pipefail
-
-          pr_number="${DISPATCH_PR_NUMBER:-${EVENT_PR_NUMBER:-}}"
-          if [ -z "$pr_number" ]; then
-            echo "No pull request number was available for this event." >&2
-            exit 1
-          fi
-          if [ -z "${TRUNK_API_TOKEN:-}" ]; then
-            echo "TRUNK_API_TOKEN was not loaded from 1Password." >&2
-            exit 1
-          fi
-
-          pr_json="$(gh pr view "$pr_number" -R "$REPOSITORY_OWNER/$REPOSITORY_NAME" --json number,state,isDraft,baseRefName,headRepositoryOwner,url)"
-          state="$(jq -r '.state' <<<"$pr_json")"
-          is_draft="$(jq -r '.isDraft' <<<"$pr_json")"
-          base_ref="$(jq -r '.baseRefName' <<<"$pr_json")"
-          head_owner="$(jq -r '.headRepositoryOwner.login' <<<"$pr_json")"
-          pr_url="$(jq -r '.url' <<<"$pr_json")"
-          default_branch="$(gh api "repos/$REPOSITORY_OWNER/$REPOSITORY_NAME" --jq '.default_branch')"
-
-          if [ "$state" != "OPEN" ]; then
-            echo "Skipping $pr_url because it is $state."
-            exit 0
-          fi
-          if [ "$is_draft" = "true" ]; then
-            echo "Skipping $pr_url because it is a draft."
-            exit 0
-          fi
-          if [ "$base_ref" != "$default_branch" ]; then
-            echo "Skipping $pr_url because its base branch ($base_ref) is not the default branch."
-            exit 0
-          fi
-          if [ "$EVENT_NAME" != "workflow_dispatch" ] && [ "$head_owner" != "$REPOSITORY_OWNER" ]; then
-            echo "Skipping $pr_url because automatic submission is limited to same-owner branches."
-            exit 0
-          fi
-
-          payload="$(
-            jq -nc \
-              --arg owner "$REPOSITORY_OWNER" \
-              --arg name "$REPOSITORY_NAME" \
-              --arg targetBranch "$base_ref" \
-              --argjson prNumber "$pr_number" \
-              '{
-                repo: {
-                  host: "github.com",
-                  owner: $owner,
-                  name: $name
-                },
-                targetBranch: $targetBranch,
-                pr: {
-                  number: $prNumber
-                }
-              }'
-          )"
-
-          response_file="$(mktemp)"
-          status="$(
-            curl --silent --show-error \
-              --max-time 30 \
-              --connect-timeout 10 \
-              --output "$response_file" \
-              --write-out "%{http_code}" \
-              --request POST \
-              --url https://api.trunk.io/v1/submitPullRequest \
-              --header "Content-Type: application/json" \
-              --header "x-api-token: $TRUNK_API_TOKEN" \
-              --data "$payload"
-          )"
-
-          if [[ "$status" =~ ^2[0-9][0-9]$ ]]; then
-            echo "Submitted $pr_url to the Trunk merge queue."
-            cat "$response_file"
-            exit 0
-          fi
-
-          if [[ "$status" == "409" ]]; then
-            echo "$pr_url was already submitted to the Trunk merge queue."
-            cat "$response_file"
-            exit 0
-          fi
-
-          echo "Trunk submit failed with HTTP $status." >&2
-          cat "$response_file" >&2
-          exit 1
+        run: scripts/submit-to-trunk-merge-queue.sh

--- a/.github/workflows/trunk-submit.yml
+++ b/.github/workflows/trunk-submit.yml
@@ -7,7 +7,7 @@ on:
         description: Pull request number to submit to Trunk
         required: true
         type: number
-  pull_request_target:
+  pull_request_target: # zizmor: ignore[dangerous-triggers] same-owner guard prevents fork PRs from reaching the secret-backed submit step
     types:
       - opened
       - reopened
@@ -24,6 +24,9 @@ permissions:
 jobs:
   submit:
     name: Submit PR to Trunk
+    concurrency:
+      group: trunk-submit-${{ github.repository }}-${{ github.event.pull_request.number || inputs.pr_number }}
+      cancel-in-progress: false
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,9 +75,9 @@ checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arraydeque"

--- a/scripts/submit-to-trunk-merge-queue.sh
+++ b/scripts/submit-to-trunk-merge-queue.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+pr_number="${DISPATCH_PR_NUMBER:-${EVENT_PR_NUMBER:-}}"
+if [[ -z "$pr_number" ]]; then
+  echo "No pull request number was available for this event." >&2
+  exit 1
+fi
+if [[ -z "${TRUNK_API_TOKEN:-}" ]]; then
+  echo "TRUNK_API_TOKEN was not loaded from 1Password." >&2
+  exit 1
+fi
+
+pr_json="$(gh pr view "$pr_number" -R "$REPOSITORY_OWNER/$REPOSITORY_NAME" --json number,state,isDraft,baseRefName,headRepositoryOwner,url)"
+state="$(jq -r '.state' <<<"$pr_json")"
+is_draft="$(jq -r '.isDraft' <<<"$pr_json")"
+base_ref="$(jq -r '.baseRefName' <<<"$pr_json")"
+head_owner="$(jq -r '.headRepositoryOwner.login' <<<"$pr_json")"
+pr_url="$(jq -r '.url' <<<"$pr_json")"
+default_branch="$(gh api "repos/$REPOSITORY_OWNER/$REPOSITORY_NAME" --jq '.default_branch')"
+
+if [[ "$state" != "OPEN" ]]; then
+  echo "Skipping $pr_url because it is $state."
+  exit 0
+fi
+if [[ "$is_draft" == "true" ]]; then
+  echo "Skipping $pr_url because it is a draft."
+  exit 0
+fi
+if [[ "$base_ref" != "$default_branch" ]]; then
+  echo "Skipping $pr_url because its base branch ($base_ref) is not the default branch."
+  exit 0
+fi
+if [[ "$EVENT_NAME" != "workflow_dispatch" && "$head_owner" != "$REPOSITORY_OWNER" ]]; then
+  echo "Skipping $pr_url because automatic submission is limited to same-owner branches."
+  exit 0
+fi
+
+payload="$(
+  jq -nc \
+    --arg owner "$REPOSITORY_OWNER" \
+    --arg name "$REPOSITORY_NAME" \
+    --arg targetBranch "$base_ref" \
+    --argjson prNumber "$pr_number" \
+    '{
+      repo: {
+        host: "github.com",
+        owner: $owner,
+        name: $name
+      },
+      targetBranch: $targetBranch,
+      pr: {
+        number: $prNumber
+      }
+    }'
+)"
+
+response_file="$(mktemp)"
+status="$(
+  curl --silent --show-error \
+    --max-time 30 \
+    --connect-timeout 10 \
+    --output "$response_file" \
+    --write-out "%{http_code}" \
+    --request POST \
+    --url https://api.trunk.io/v1/submitPullRequest \
+    --header "Content-Type: application/json" \
+    --header "x-api-token: $TRUNK_API_TOKEN" \
+    --data "$payload"
+)"
+
+if [[ "$status" =~ ^2[0-9][0-9]$ ]]; then
+  echo "Submitted $pr_url to the Trunk merge queue."
+  cat "$response_file"
+  exit 0
+fi
+
+if [[ "$status" == "409" ]]; then
+  echo "$pr_url was already submitted to the Trunk merge queue."
+  cat "$response_file"
+  exit 0
+fi
+
+echo "Trunk submit failed with HTTP $status." >&2
+cat "$response_file" >&2
+exit 1


### PR DESCRIPTION
Adds a small Trunk submit workflow for the post-transfer merge queue setup.

The workflow:
- loads `TRUNK_API_TOKEN` from the shared 1Password `Github Secrets` vault using the repo's existing `OP_SERVICE_ACCOUNT_TOKEN` secret;
- submits non-draft same-owner PRs against the default branch when they open, update, or receive an approval;
- supports manual submission through `workflow_dispatch` with a PR number;
- does not checkout PR code or run untrusted scripts under `pull_request_target`.

This complements the Trunk branch rulesets; GitHub's native merge button is not what enters a PR into Trunk's queue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new workflow to submit qualifying pull requests to Trunk’s merge queue, including manual and event-based triggering.
  * Updated the release workflow to use a pinned reusable workflow version for more consistent releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->